### PR TITLE
persistence_boot_or_logon_IS_rc_script

### DIFF
--- a/mitre/Persistence/Boot or Logon Initialization Scripts/Containers/persistence_boot_or_logon_IS_rc_script.yaml
+++ b/mitre/Persistence/Boot or Logon Initialization Scripts/Containers/persistence_boot_or_logon_IS_rc_script.yaml
@@ -3,6 +3,7 @@ kind: KubeArmorPolicy
 metadata:
   name: persistence-blis-rc-scripts
 spec:
+  tags: ["MITRE", "Persistence"]
   severity: 5
   selector:
     matchLabels:


### PR DESCRIPTION
Adversaries may establish persistence by modifying RC scripts which are executed during a Unix-like system’s startup.

Adversaries can establish persistence by adding a malicious binary path or shell commands to rc.local, rc.common, and other RC scripts specific to the Unix-like distribution. Upon reboot, the system executes the script's contents as root, resulting in persistence.

reference:
https://attack.mitre.org/techniques/T1037/004/