### PR TITLE
persistence_create_or_modify_system_process_systemd_service

### DIFF
--- a/mitre/internal/generic/system/persistence_create_or_modify_system_process_systemd_service.yaml
+++ b/mitre/internal/generic/system/persistence_create_or_modify_system_process_systemd_service.yaml
@@ -3,7 +3,7 @@ kind: KubeArmorPolicy
 metadata:
   name: create-or-modify-system-process-systemd-service
 spec:
-  tags: ["MITRE", "Persisrence"]
+  tags: ["MITRE", "Persistence"]
   severity: 5
   selector:
     matchLabels:


### PR DESCRIPTION
Adversaries may create or modify systemd services to repeatedly execute malicious payloads as part of persistence. The systemd service manager is commonly used for managing background daemon processes (also known as services) and other system resources. Systemd is the default initialization (init) system on many Linux distributions starting with Debian 8, Ubuntu 15.04, CentOS 7, RHEL 7, Fedora 15, and replaces legacy init systems including SysVinit and Upstart while remaining backwards compatible with the aforementioned init systems.

reference:
https://attack.mitre.org/techniques/T1543/002/ 