### PR TITLE
[Rule] Execution Isolation - Shell Access inside a container

### DIFF
--- a/mitre/internal/d3fend/execution-isolation/Executable-Denylisting/unix-shell-execution/shell-policy.yaml
+++ b/mitre/internal/d3fend/execution-isolation/Executable-Denylisting/unix-shell-execution/shell-policy.yaml
@@ -27,6 +27,7 @@ spec:
         recursive: true    
       severity: 2 # Higher severity for processes 
   file:
+    matchPaths:
     - path: /bin/bash
     - path: /bin/sh
     - path: /usr/bin/bash


### PR DESCRIPTION
Blocking the unknown shell access attempted in any container.

Refer D3fend Matrix Rule here - [https://d3fend.mitre.org/technique/d3f:ExecutableDenylisting](https://d3fend.mitre.org/technique/d3f:ExecutableDenylisting)