### PR TITLE
unsecured_credentials_access_private_keys

### DIFF
--- a/mitre/internal/generic/system/unsecured_credentials_access.yaml
+++ b/mitre/internal/generic/system/unsecured_credentials_access.yaml
@@ -2,12 +2,11 @@ apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
   name: mitre-tactic-credential-access-unsecured-credentials-private-keys
-  namespace: {}
 spec:
   severity: 6
   selector:
     matchLabels:
-      container: {}
+      {}
   file:
     matchDirectories:
       - dir: /etc/ssl/


### PR DESCRIPTION
Adversaries may search for private key certificate files on compromised systems for insecurely stored credentials. Private cryptographic keys and certificates are used for authentication, encryption/decryption, and digital signatures.

Reference: https://attack.mitre.org/techniques/T1552/004/