### PR TITLE
discovery_account_discovery_local_account

### DIFF
--- a/mitre/internal/generic/system/discovery_account_discovery_local_account.yaml
+++ b/mitre/internal/generic/system/discovery_account_discovery_local_account.yaml
@@ -3,6 +3,7 @@ kind: KubeArmorPolicy
 metadata:
   name: discovery-account-discovery-local-account
 spec:
+  tags: ["MITRE", "Discovery"]
   severity: 5
   selector:
     matchLabels:


### PR DESCRIPTION
Adversaries may attempt to get a listing of local system accounts. This information can help adversaries determine which local accounts exist on a system to aid in follow-on behavior.

reference:
https://attack.mitre.org/techniques/T1087/001/