### PR TITLE
Credential-access-pswd(/etc/passwd and /etc/shadow)

### DIFF
--- a/credential-access-pswd.yaml
+++ b/credential-access-pswd.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-credential-access-password-dumping
+
+spec:
+  tags: ["MITRE"]
+  message: credential-access-password-dumping
+  selector:
+      matchLabels:
+          {}
+  file:
+    matchPaths: 
+    - path: /etc/passwd
+    - path: /etc/shadow
+  action:
+    Audit
+  severity: 4


### PR DESCRIPTION
Adversaries may attempt to dump the contents of /etc/passwd and /etc/shadow to enable offline password cracking.