### PR TITLE
persistence_boot_or_logon_IS_rc_script

### DIFF
--- a/mitre/internal/generic/system/persistence_boot_or_logon_IS_rc_script.yaml
+++ b/mitre/internal/generic/system/persistence_boot_or_logon_IS_rc_script.yaml
@@ -1,0 +1,38 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: persistence-blis-rc-scripts
+spec:
+  tags: ["MITRE", "Persistence"]
+  severity: 5
+  selector:
+    matchLabels:
+      {}
+  process:
+    matchPaths:
+      - path: /etc/rc.local
+      - path: /lib/systemd/system/rc-local.service
+      - path: /lib/systemd/system/rc.service
+      - path: /usr/lib/systemd/system/rc-local.service
+      - path: /usr/lib/systemd/system/rc.service
+    matchDirectories:
+      - dir: /lib/systemd/system/rc-local.service.d/
+        recursive: true
+      - dir: /usr/lib/systemd/system/rc-local.service.d/
+        recursive: true
+  file:
+    matchPaths:
+      - path: /etc/rc.local
+      - path: /lib/systemd/system/rc-local.service
+      - path: /lib/systemd/system/rc.service
+      - path: /usr/lib/systemd/system/rc-local.service
+      - path: /usr/lib/systemd/system/rc.service
+    matchDirectories:
+      - dir: /lib/systemd/system/rc-local.service.d/
+        recursive: true
+        readOnly: false
+      - dir: /usr/lib/systemd/system/rc-local.service.d/
+        recursive: true
+        readOnly: false
+  action:
+    Audit


### PR DESCRIPTION
Adversaries can establish persistence by adding a malicious binary path or shell commands to rc.local, rc.common, and other RC scripts specific to the Unix-like distribution. Upon reboot, the system executes the script's contents as root, resulting in persistence.
Adversary abuse of RC scripts is especially effective for lightweight Unix-like distributions using the root user as default, such as IoT or embedded systems.

Reference:
https://attack.mitre.org/techniques/T1037/004/