### PR TITLE
postgresql-config-dir

### DIFF
--- a/mitre/internal/postgres/system/postgresql-config-dir.yaml
+++ b/mitre/internal/postgres/system/postgresql-config-dir.yaml
@@ -1,0 +1,19 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: postgresql-config-directory
+spec:
+  tags: ["PostgreSQL"]
+  severity: 5
+  selector:
+    matchLabels:
+      {}
+  file:
+    matchDirectories:
+      - dir: /etc/postgresql/
+        recursive: true
+        readOnly: false
+      - dir: /etc/postgresql-common/
+        recursive: true
+        readOnly: false
+    action: Audit


### PR DESCRIPTION
The attacker or other users may try to access the PostgreSQL configuration file. If they can access the configuration file, they can retrieve important information or they can change the configuration of PostgreSQL.