### PR TITLE
Persistence-create-account-local-account

### DIFF
--- a/mitre/internal/generic/system/Persistence-createaccount-local-account.yaml
+++ b/mitre/internal/generic/system/Persistence-createaccount-local-account.yaml
@@ -1,0 +1,19 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-persistence-createaccount-localaccount
+spec:
+  severity: 4
+  selector:
+    matchLabels: 
+      {}
+  process:
+    matchPaths:
+      - path: /usr/sbin/adduser
+      - path: /usr/sbin/useradd
+  file:
+    matchPaths:
+      - path: /etc/passwd
+      - path: /etc/shadow
+  action: 
+    Audit


### PR DESCRIPTION
Adversaries may create a local account to maintain access to victim systems. Local accounts are those configured by an organization for use by users, remote support, services, or for administration on a single system or service.

Reference: https://attack.mitre.org/techniques/T1136/001/