### PR TITLE
Boot-or-Logon-Autostart-Execution

### DIFF
--- a/mitre/internal/generic/system/Boot-or-Logon-Autostart-Execution.yaml
+++ b/mitre/internal/generic/system/Boot-or-Logon-Autostart-Execution.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-persistence-boot-or-logon-autostart-execution-kernel-modules-and-extensions
+spec:
+  severity: 4
+  selector:
+    matchLabels:
+      {}
+  process:
+    matchPaths:
+      - path: /usr/sbin/modprobe 
+      - path: /usr/sbin/insmod 
+      - path: /usr/sbin/modinfo
+      - path: /usr/sbin/lsmod
+  action: 
+    Audit


### PR DESCRIPTION
Adversaries may modify the kernel to automatically execute programs on system boot. Loadable Kernel Modules (LKMs) are pieces of code that can be loaded and unloaded into the kernel upon demand. They extend the functionality of the kernel without the need to reboot the system.

Reference: https://attack.mitre.org/techniques/T1547/006/