### PR TITLE
Cilium Network Policy to limit MySql pod communications 

### DIFF
--- a/mitre/internal/mysql/Network-Ingress/allow-mysql-pod-communication-on-3306-and-namespace.yml
+++ b/mitre/internal/mysql/Network-Ingress/allow-mysql-pod-communication-on-3306-and-namespace.yml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-mysql-pod-communication-on-3306-and-namespace"
+spec:
+  endpointSelector:
+    matchLabels:
+      {}
+  ingress: 
+  - fromEndpoints:
+    - matchLabels:
+        {}
+    toPorts:
+    -  ports:
+       -  port: '3306'
+          protocol: ANY


### PR DESCRIPTION
The policy makes use of MITRE D3FEND Network Isolation > Inbound Traffic Filtering
The idea is to limit the pod's communication to all namespaces or pods via all known ports and to impose filtering such as 

- Blocking specific ports and services from establishing connections
- Limiting specific IP ranges from connecting to the network

Reference: https://d3fend.mitre.org/technique/d3f:InboundTrafficFiltering