### PR TITLE
postgres-pg-ctl-audit

### DIFF
--- a/mitre/internal/postgres/system/postgres-pg-ctl-audit.yaml
+++ b/mitre/internal/postgres/system/postgres-pg-ctl-audit.yaml
@@ -1,0 +1,32 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-postgres-pgctl-cluster
+spec:
+  selector:
+      matchLabels:
+          {}
+  process:
+    matchPaths:
+    - path: /usr/bin/pg_ctlcluster
+    - path: /var/log/postgresql
+    - path: /usr/lib/postgresql/13/bin/pg_ctl
+      fromSource: # trigger an alert if the source
+        - dir: /usr/
+        - dir: /usr/lib/
+        - dir: /var/log/
+          recursive: true  
+    severity: 5 # Higher severity 
+  file:
+    matchPaths: 
+    - path: /usr/bin/pg_ctlcluster
+    - path: /var/log/postgresql
+    - path: /usr/lib/postgresql/13/bin/pg_ctl
+      fromSource: # trigger an alert if the source
+       - path: /usr
+       - path: /lib
+       - path: /var
+  action:
+    Audit
+  severity: 9 # lowest severity
+  tags : ["postgres","CVE-2016-1255"]


### PR DESCRIPTION
postgres-pg-ctl-audit [CVE-2016-1255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1255) 
The pg_ctlcluster script in postgresql-common package in Debian wheezy before 134wheezy5, in Debian jessie before 165+deb8u2, in Debian unstable before 178, in Ubuntu 12.04 LTS before 129ubuntu1.2, in Ubuntu 14.04 LTS before 154ubuntu1.1, in Ubuntu 16.04 LTS before 173ubuntu0.1, in Ubuntu 17.04 before 179ubuntu0.1, and in Ubuntu 17.10 before 184ubuntu1.1 allows local users to gain root privileges via a symlink attack on a logfile in /var/log/postgresql.