### PR TITLE
defense-evasion-root-certificate

### DIFF
--- a/mitre/internal/generic/system/defense-evasion-root-certificate.yaml
+++ b/mitre/internal/generic/system/defense-evasion-root-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defense-evasion-root-certificate
+spec:
+  severity: 6
+  selector:
+    matchLabels:
+      {}
+  file:
+    matchPaths:
+       - path: /etc/ca-certificates.conf
+    matchDirectories:
+       - dir: /usr/local/share/ca-certificates/
+         recursive: true
+  action: Audit


### PR DESCRIPTION
Ref:https://attack.mitre.org/techniques/T1553/004/
Adversaries may install a root certificate on a compromised system to avoid warnings when connecting to adversary controlled web servers. Root certificates are used in public key cryptography to identify a root certificate authority (CA). When a root certificate is installed, the system or application will trust certificates in the root's chain of trust that have been signed by the root certificate.