### PR TITLE
cilium network policy to restrict the MySQL external communication

### DIFF
--- a/mitre/internal/mysql/Network-Egress/deny-external-communication-from-mysql-pod.yml
+++ b/mitre/internal/mysql/Network-Egress/deny-external-communication-from-mysql-pod.yml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "deny-external-communication-from-mysql-pod"
+spec:
+  endpointSelector:
+    matchLabels:
+      {}
+  egressDeny:
+  - toEntities:
+    - "world"
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        {}


### PR DESCRIPTION
The proposed CIliumNetwork Policy makes use of egressDeny functionality and makes sure that the MySQL pod cannot communicate to the outside world and can only connect to particular pods and namespaces.

Ref: https://d3fend.mitre.org/technique/d3f:OutboundTrafficFiltering