### PR TITLE
alertsservice-KL-service

### DIFF
--- a/services/alertsservice/alertsservice.yaml
+++ b/services/alertsservice/alertsservice.yaml
@@ -9,7 +9,7 @@ spec:
       {}
   ingress:
     - fromCIDR:
-        - 10.52.0.0/32
+        {}
       toPorts:
       - ports:
         - port: "8095"


### PR DESCRIPTION
This policy will block port 8095 external access and it will allow only CIDR IPs.