### PR TITLE
postgres-network-ingress

### DIFF
--- a/mitre/internal/postgres/Network-Ingress/postgres-network-ingress.yaml
+++ b/mitre/internal/postgres/Network-Ingress/postgres-network-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "postgresql-port"
+spec:
+  description: "This will block postgresql external access"
+  endpointSelector:
+    matchLabels:
+      {}
+  ingress:
+    - fromCIDR:
+        {}
+      toPorts:
+      - ports:
+        - port: "5432"
+          protocol: ANY


### PR DESCRIPTION
This policy will block port 5432 external access and it will allow only CIDR IPs.