### PR TITLE
persistence_boot_or_logon_IS_rc_script_host

### DIFF
--- a/mitre/internal/generic/host/persistence_boot_or_logon_IS_rc_script.yaml
+++ b/mitre/internal/generic/host/persistence_boot_or_logon_IS_rc_script.yaml
@@ -7,7 +7,7 @@ spec:
   severity: 5
   nodeSelector:
     matchLabels:
-      kubernetes.io/hostname: gke-cluster-1-default-pool-2cf526a2-t7j3
+      {}
   file:
     matchPaths:
       - path: /etc/rc.local


### PR DESCRIPTION
Adversaries can establish persistence by adding a malicious binary path or shell commands to rc.local, rc.common, and other RC scripts specific to the Unix-like distribution. Upon reboot, the system executes the script's contents as root, resulting in persistence.
Adversary abuse of RC scripts is especially effective for lightweight Unix-like distributions using the root user as default, such as IoT or embedded systems.

Reference:
https://attack.mitre.org/techniques/T1037/004/