### PR TITLE
alertsservice

### DIFF
--- a/services/alertsservice/alertsservice.yaml
+++ b/services/alertsservice/alertsservice.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "alertsservice-port"
+spec:
+  description: "This will block alertsservice external access"
+  endpointSelector:
+    matchLabels:
+      {}
+  ingress:
+    - fromCIDR:
+        {}
+      toPorts:
+      - ports:
+        - port: "8095"
+          protocol: TCP


### PR DESCRIPTION
This policy will block port 8095 external access and it will allow only CIDR IPs.