### PR TITLE
cs-restrict-access-mysql-config-policy

### DIFF
--- a/mitre/workload/mysql/system/cs-restrict-access-mysql-config-policy.yaml
+++ b/mitre/workload/mysql/system/cs-restrict-access-mysql-config-policy.yaml
@@ -2,7 +2,6 @@ apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
   name: restrict-access-mysql-config
-  namespace: {}
 spec:
   message: "block access to dir /etc/mysql/"
   selector:
@@ -12,9 +11,10 @@ spec:
     matchDirectories:
     - dir: /etc/mysql/  # <--- mysql directory
       recursive: true
+    action: Block
   process:
     severity: 5
     matchPaths:
       - path: /bin/cd
-  action:
-    Block
+    action: Block
+


### PR DESCRIPTION
The MySQL Database Server 8.0 must enforce access restrictions associated with changes to the configuration of the MySQL Database Server 8.0 or database(s).