### PR TITLE
SV-233593r617333_rule

### DIFF
--- a/stigs/workload/postgres/system/SV-233593r617333_rule.yaml
+++ b/stigs/workload/postgres/system/SV-233593r617333_rule.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     matchLabels: 
-      app: postgres
+      {}
   file:
     severity: 3
     matchDirectories:


### PR DESCRIPTION
Access to external executables must be disabled or restricted.