### PR TITLE
ingress-tool used for sharing from affected system

### DIFF
--- a/mitre/workload/generic/system/command-and-control-ingress-tool.yaml
+++ b/mitre/workload/generic/system/command-and-control-ingress-tool.yaml
@@ -1,0 +1,19 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: command-and-control-ingress-tool
+spec:
+  severity: 4                     
+  tags: ["mitre", "command-and-control"]                       
+  message: Files can also be copied over on Mac and Linux with native tools like scp, rsync, and sftp
+  selector:
+    matchLabels:
+      {}
+  process:
+    matchPaths:
+       - path: /usr/bin/sftp 
+       - path: /usr/bin/rsync
+       - path: /usr/bin/scp
+       - path: /usr/bin/whois
+  action:
+    Audit


### PR DESCRIPTION
Adversaries may transfer tools or other files from an external system into a compromised environment. Files may be copied from an external adversary controlled system through the command and control channel to bring tools into the victim network or through alternate protocols with another tool such as FTP. Files can also be copied over on Mac and Linux with native tools like scp, rsync, and sftp.