### PR TITLE
hsp-mitre-create-modify-system-process-systemd-service

### DIFF
--- a/mitre/host/generic/system/hsp-mitre-create-modify-system-process-systemd-service.yaml
+++ b/mitre/host/generic/system/hsp-mitre-create-modify-system-process-systemd-service.yaml
@@ -1,0 +1,38 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: hsp-mitre-create-or-modify-system-process-systemd-service
+spec:
+  message: Create or modify system process and systemd service 
+  tags: ["MITRE"]
+  nodeSelector:
+    matchLabels:
+      {}
+  process:
+    severity: 3
+    matchDirectories:
+      - dir: /etc/systemd/system/
+        recursive: true
+      - dir: /usr/lib/systemd/
+        recursive: true
+      - dir: /lib/systemd/system/
+        recursive: true
+      - dir: /home/user/.config/systemd/user/
+        recursive: true
+    action: Audit
+  file:
+    severity: 3
+    matchDirectories:
+      - dir: /etc/systemd/system/
+        recursive: true
+        readOnly: false
+      - dir: /usr/lib/systemd/
+        recursive: true
+        readOnly: false
+      - dir: /lib/systemd/system/
+        recursive: true
+        readOnly: false
+      - dir: /home/user/.config/systemd/user/
+        recursive: true
+        readOnly: false
+    action: Audit


### PR DESCRIPTION
Adversaries may create or modify systemd services to repeatedly execute malicious payloads as part of persistence. The systemd service manager is commonly used for managing background daemon processes (also known as services) and other system resources.Systemd is the default initialization (init) system on many Linux distributions starting with Debian 8, Ubuntu 15.04, CentOS 7, RHEL 7, Fedora 15, and replaces legacy init systems including SysVinit and Upstart while remaining backwards compatible with the aforementioned init systems.