### PR TITLE
pki-certificates

### DIFF
--- a/nist/workload/system/pki-certificates.yaml
+++ b/nist/workload/system/pki-certificates.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: sc-17-public-key-infrastructure-certificates
+spec:
+  selector:
+    matchLabels:
+      {}
+  file:
+    severity: 5
+    matchDirectories:
+      - dir: /etc/pki/
+        recursive: true
+      - dir: /etc/ssl/certs/
+        recursive: true
+      - dir: /usr/local/share/ca-certificates/
+        recursive: true
+    action: Block


### PR DESCRIPTION
Public key infrastructure (PKI) certificates are certificates with visibility external to organizational systems and certificates related to the internal operations of systems, such as application-specific time services.