### PR TITLE
application-layer-protocol-ftp-ingress

### DIFF
--- a/mitre/workload/generic/network-ingress/application-layer-protocol-ftp-ingress.yaml
+++ b/mitre/workload/generic/network-ingress/application-layer-protocol-ftp-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app: postgres
+      {}
   ingress:
     - toPorts:
         - ports:


### PR DESCRIPTION
Adversaries may communicate using application layer protocols associated with transferring files to avoid detection/network filtering by blending in with existing traffic.