### PR TITLE
application-layer-protocol-ftp-egress

### DIFF
--- a/mitre/workload/generic/network-egress/application-layer-protocol-ftp-egress.yaml
+++ b/mitre/workload/generic/network-egress/application-layer-protocol-ftp-egress.yaml
@@ -1,0 +1,18 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "FTP-rule"
+spec:
+  endpointSelector:
+    matchLabels: {}
+  egress:
+    - toPorts:
+        - ports:
+            - port: "20"
+              protocol: TCP
+            - port: "21"
+              protocol: TCP
+            - port: "990"
+              protocol: TCP
+            - port: "69"
+              protocol: UDP


### PR DESCRIPTION
Adversaries may communicate using application layer protocols associated with transferring files to avoid detection/network filtering by blending in with existing traffic.