### PR TITLE
nist-cm-7-2-least-func-prevent-auto-exec-block

### DIFF
--- a/nist/workload/generic/system/nist-cm-7-2-least-func-prevent-auto-exec-block.yaml
+++ b/nist/workload/generic/system/nist-cm-7-2-least-func-prevent-auto-exec-block.yaml
@@ -1,0 +1,20 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: nist-cm-7-2-least-func-prevent-auto-exec-block
+  namespace: multiubuntu # add your own namespace
+spec:
+  tags: ["NIST", "CM-7(2)"]
+  message: "This policy will block auto-execution programs (ex:crontab)" 
+  selector:
+    matchLabels:
+      container: ubuntu-1 # add your own match labels
+  process:
+    severity: 2
+    matchPaths:
+    - path: /etc/crontab # try crontab (permission denied)
+    - path: /etc/anacrontab
+    - path: /etc/fcrontab
+    - path: /etc/hcron
+    - path: /etc/jobber
+    action: Block


### PR DESCRIPTION
Block the process that auto-execute features in the pods also block external programs that modifying
the system programs or process.