### PR TITLE
nist-cm-7-1-least-func-periodic-review

### DIFF
--- a/nist/network/nist-cm-7-1-least-func-periodic-review.yaml
+++ b/nist/network/nist-cm-7-1-least-func-periodic-review.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: "nist-cm-7-1-least-func-periodic-review"
+spec:
+  description: "Prohibit or restrict the use of the default ports open in containers."
+  endpointSelector:
+    matchLabels:
+      app: myService # add your own match labels here
+  ingressDeny:
+  - toPorts:
+    - ports:
+      - port: "21"
+        protocol: ANY
+      - port: "53"
+        protocol: ANY
+      - port: "80"
+        protocol: ANY
+      - port: "110"
+        protocol: ANY
+      - port: "23"
+        protocol: ANY


### PR DESCRIPTION
Prohibit or restrict the use of the default  functions, ports, protocols, software, and/or
services