### PR TITLE
ksp-mitre-T1543-002

### DIFF
--- a/mitre/system/ksp-mitre-T1543-002.yaml
+++ b/mitre/system/ksp-mitre-T1543-002.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ksp-mitre-T1543-002
 spec:
   tags: ["HOST", "MITRE", "PERSISTENCE"]
-  message: "someone tried to access system process files"
+  message: "Someone Tried to Access System Process Files"
   nodeSelector:
     matchLabels:
       pod: testpod


### PR DESCRIPTION
Adversaries may create or modify systemd services to repeatedly execute malicious payloads as part of persistence. The systemd service manager is commonly used for managing background daemon processes (also known as services) and other system resources. Systemd is the default initialization (init) system on many Linux distributions starting with Debian 8, Ubuntu 15.04, CentOS 7, RHEL 7, Fedora 15, and replaces legacy init systems including SysVinit and Upstart while remaining backwards compatible with the aforementioned init systems.

reference:
https://attack.mitre.org/techniques/T1543/002/