### PR TITLE
ksp-mitre-T1087-001

### DIFF
--- a/mitre/system/ksp-mitre-T1087-001.yaml
+++ b/mitre/system/ksp-mitre-T1087-001.yaml
@@ -1,0 +1,24 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-mitre-T1087-001
+spec:
+  tags: ["MITRE", "DISCOVERY"]
+  message: "Someone Tried to Access Local User Account Details"
+  selector:
+    matchLabels:
+      pod: testpod
+  process:
+    severity: 5
+    matchPaths:
+      - path: /usr/bin/id
+      - path: /usr/bin/groups
+      - path: /usr/bin/net
+      - path: /usr/bin/finger
+      - path: /usr/bin/getent
+      - path: /usr/bin/lslogins
+      - path: /usr/bin/users
+      - path: /usr/bin/w
+      - path: /usr/bin/last
+      - path: /usr/bin/lastlog
+    action: Audit


### PR DESCRIPTION
Adversaries may attempt to get a listing of local system accounts. This information can help adversaries determine which local accounts exist on a system to aid in follow-on behavior.

reference:
https://attack.mitre.org/techniques/T1087/001/