### PR TITLE
ksp-mysql-files-access-limit

### DIFF
--- a/stigs/system/ksp-stigs-mysql-files-access-limit.yaml
+++ b/stigs/system/ksp-stigs-mysql-files-access-limit.yaml
@@ -3,7 +3,7 @@ kind: KubeArmorPolicy
 metadata:
   name: ksp-mysql-files-access-limit
 spec:
-  tags: ["MYSQL"]
+  tags: ["STIGS", "MYSQL"]
   message: "Someone Tried to Access MySQL Files"
   selector:
     matchLabels:


### PR DESCRIPTION
Most of the MySQL installation can be owned by root. The exceptions are the data directory, the error log file, the MySQL-files directory, the PID file, and the socket file, to which the MySQL user must have write access. Files and resources to which the MySQL user requires read access include configuration files (/etc/my.cnf) and the MySQL binaries (for example /usr/local/mysql/bin).