### PR TITLE
ksp-postgresql-private-keys

### DIFF
--- a/stigs/system/ksp-stigs-postgresql-private-keys.yaml
+++ b/stigs/system/ksp-stigs-postgresql-private-keys.yaml
@@ -1,9 +1,9 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
-  name: ksp-postgresql-private-keys
+  name: ksp-stigs-postgresql-private-keys
 spec:
-  tags: ["POSTGRESQL"]
+  tags: ["STIGS", "POSTGRESQL"]
   message: "Someone Tried to Access Private Keys"
   selector:
     matchLabels:


### PR DESCRIPTION
We have to protect PostgreSQL private keys from other users.