### PR TITLE
ksp-postgresql-console

### DIFF
--- a/stigs/system/ksp-stigs-postgresql-console.yaml
+++ b/stigs/system/ksp-stigs-postgresql-console.yaml
@@ -1,9 +1,9 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
-  name: ksp-postgresql-console
+  name: ksp-stigs-postgresql-console
 spec:
-  tags: ["POSTGRESQL"]
+  tags: ["STIGS", "POSTGRESQL"]
   message: "Someone Tried to Access PostgreSQL Database"
   selector:
     matchLabels:


### PR DESCRIPTION
Do not allow general users to access the PostgreSQL console. Send an alert if any user tried to access the PostgreSQL console.