### PR TITLE
cnp-postgresql-port-external-access

### DIFF
--- a/stigs/network/cnp-stigs-postgresql-port-external-access.yaml
+++ b/stigs/network/cnp-stigs-postgresql-port-external-access.yaml
@@ -6,7 +6,7 @@ spec:
   description: "This will Block PostgreSQL External Access"
   endpointSelector:
     matchLabels:
-      pod: testpod
+      pod: testpod   #change this label with your label
   ingress:
     - fromEntities:
         - cluster


### PR DESCRIPTION
This policy will block port 5432 external access and will allow only CIDR IPs.