### PR TITLE
cnp-alertsservice-port-external-access

### DIFF
--- a/stigs/network/cnp-alertsservice-port-external-access.yaml
+++ b/stigs/network/cnp-alertsservice-port-external-access.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-alertsservice-port-external-access
+spec:
+  description: "This will Block Alertsservice External Access"
+  endpointSelector:
+    matchLabels:
+      pod: test
+  ingress:
+    - fromEntities:
+        - cluster
+    - fromCIDRSet:
+        - {}
+      toPorts:
+        - ports:
+            - port: "8095"


### PR DESCRIPTION
This policy will block port 8095 external access and it will allow only CIDR IPs