### PR TITLE
cnp-pci-dss-1.3.3-ingress

### DIFF
--- a/pci-dss/network/cnp-pci-dss-1.3.3-ingress.yaml
+++ b/pci-dss/network/cnp-pci-dss-1.3.3-ingress.yaml
@@ -3,10 +3,11 @@ kind: CiliumNetworkPolicy
 metadata:
   name: cnp-pci-dss-1.3.3-ingress
 spec:
-  description: "This will Block inbound connection from Internet"
   endpointSelector:
     matchLabels:
-      pad: testpad
+      pod: testpod  #change this label with your label
   ingress:
     - fromEntities:
         - cluster
+    - fromCIDRSet:
+        - cidr: 10.10.10.1/16  #change with your id address


### PR DESCRIPTION
Do not allow any direct connections inbound for traffic between the Internet and the cardholder data environment.