### PR TITLE
cnp-nist-ac-3-3-limit-pod-ingress

### DIFF
--- a/nist/network/cnp-nist-ac-3-3-limit-pod-ingress.yaml
+++ b/nist/network/cnp-nist-ac-3-3-limit-pod-ingress.yaml
@@ -1,12 +1,12 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: cnp-nist-limit-pod-ingress
+  name: cnp-nist-ac-3-3-limit-pod-ingress
 spec:
   description: "This Policy will Restrict Pod to Pod Communication within the Namespace"
   endpointSelector:
     matchLabels:
-      pad: test
+      pod: testpod  #change this label with your label
   ingress:
     - fromEndpoints:
         - {}

--- a/nist/network/cnp-nist-ac-3-3-limit-pod-ingress.yaml
+++ b/nist/network/cnp-nist-ac-3-3-limit-pod-ingress.yaml
@@ -2,8 +2,9 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: cnp-nist-ac-3-3-limit-pod-ingress
+  namespace: default   #change with your namespace
 spec:
-  description: "This Policy will Restrict Pod to Pod Communication within the Namespace"
+  description: "This Policy will only allow all Pods in the same namespace"
   endpointSelector:
     matchLabels:
       pod: testpod  #change this label with your label

--- a/nist/network/cnp-nist-limit-pod-ingress.yaml
+++ b/nist/network/cnp-nist-limit-pod-ingress.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-nist-limit-pod-ingress
+spec:
+  description: "This Policy will Limits Pod to Pod Communication within the Namespace"
+  endpointSelector:
+    matchLabels:
+      pad: test
+  ingress:
+    - fromEndpoints:
+        - {}

--- a/nist/network/cnp-nist-limit-pod-ingress.yaml
+++ b/nist/network/cnp-nist-limit-pod-ingress.yaml
@@ -3,7 +3,7 @@ kind: CiliumNetworkPolicy
 metadata:
   name: cnp-nist-limit-pod-ingress
 spec:
-  description: "This Policy will Limit Pod to Pod Communication within the Namespace"
+  description: "This Policy will Restrict Pod to Pod Communication within the Namespace"
   endpointSelector:
     matchLabels:
       pad: test

--- a/nist/network/cnp-nist-limit-pod-ingress.yaml
+++ b/nist/network/cnp-nist-limit-pod-ingress.yaml
@@ -3,7 +3,7 @@ kind: CiliumNetworkPolicy
 metadata:
   name: cnp-nist-limit-pod-ingress
 spec:
-  description: "This Policy will Limits Pod to Pod Communication within the Namespace"
+  description: "This Policy will Limit Pod to Pod Communication within the Namespace"
   endpointSelector:
     matchLabels:
       pad: test


### PR DESCRIPTION
This Policy will Restrict Pod to Pod Communication within the Namespace