### PR TITLE
ksp-mitre-hidden-pid-preload-library

### DIFF
--- a/mitre/system/ksp-mitre-hidden-pid-preload-library.yaml
+++ b/mitre/system/ksp-mitre-hidden-pid-preload-library.yaml
@@ -2,6 +2,7 @@ apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
   name: ksp-mitre-hidden-pid-preload-library
+  namespace: default
 spec:
   tags: ["MITRE","T1574.006"]
   message: "Audit the hidden process in system and linked library"

--- a/mitre/system/ksp-mitre-hidden-pid-preload-library.yaml
+++ b/mitre/system/ksp-mitre-hidden-pid-preload-library.yaml
@@ -20,9 +20,4 @@ spec:
     severity: 2
     matchPaths:
     - path: /etc/ld.so.preload
-    - path: /proc/1/cmdline
-    - path: /proc/1/status
-    - path: /proc/1/stat
     action: Audit
-
-

--- a/mitre/system/ksp-mitre-hidden-pid-preload-library.yaml
+++ b/mitre/system/ksp-mitre-hidden-pid-preload-library.yaml
@@ -1,0 +1,28 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-mitre-hidden-pid-preload-library
+spec:
+  tags: ["MITRE","T1574.006"]
+  message: "Audit the hidden process in system and linked library"
+  selector:
+    matchLabels:
+      container: ubuntu # Change your own labels
+  file:
+    severity: 2
+    matchDirectories:
+    - dir: /proc/
+    - dir: /usr/local/lib/
+    matchPaths:
+    - path: /etc/ld.so.preload
+    action: Audit
+  process:
+    severity: 2
+    matchPaths:
+    - path: /etc/ld.so.preload
+    - path: /proc/1/cmdline
+    - path: /proc/1/status
+    - path: /proc/1/stat
+    action: Audit
+
+


### PR DESCRIPTION
**Description:**
Adversaries may execute their own malicious payloads by hijacking environment variables the dynamic linker uses to load shared libraries. During the execution preparation phase of a program, the dynamic linker loads specified absolute paths of shared libraries from environment variables and files, such as _LD_PRELOAD on_ Linux.

**Use cases:**
On Linux, adversaries may set _LD_PRELOAD_ to point to malicious libraries that match the name of legitimate libraries which are requested by a victim program, causing the operating system to load the adversary's malicious code upon execution of the victim program. _LD_PRELOAD_ can be set via the environment variable or _/etc/ld.so.preload_ file.Libraries specified by _LD_PRELOAD_ are loaded and mapped into memory by _dlopen()_ and _mmap()_ respectively.

Ref: https://attack.mitre.org/techniques/T1574/006/