### PR TITLE
ksp-nist-cp-2-8-critical-system-files

### DIFF
--- a/nist/system/ksp-nist-cp-2-8-critical-system-files.yaml
+++ b/nist/system/ksp-nist-cp-2-8-critical-system-files.yaml
@@ -3,64 +3,90 @@ kind: KubeArmorPolicy
 metadata:
   name: ksp-nist-cp-2-8-critical-system-files
 spec:
-  tags: ["STIGS", "MYSQL"]
-  message: "Someone Tried to Access MySQL Files"
+  tags: ["NIST", "CP-2-8"]
+  message: "Someone Tried Open Critical System Files"
   selector:
     matchLabels:
-      pod: testpod
+      pod: testpod   #change this label with your label
   file:
     severity: 5
     matchPaths:
     - path: /etc/fstab
+      readOnly: false
       ownerOnly: true
     - path: /etc/crontab
+      readOnly: false
       ownerOnly: true
     - path: /etc/group
+      readOnly: false
       ownerOnly: true
     - path: /etc/hosts
+      readOnly: false
       ownerOnly: true
     - path: /etc/hosts.allow
+      readOnly: false
       ownerOnly: true
     - path: /etc/hosts.deny
+      readOnly: false
       ownerOnly: true
     - path: /etc/issue
+      readOnly: false
       ownerOnly: true
     - path: /etc/motd
+      readOnly: false
       ownerOnly: true
     - path: /etc/mtab
+      readOnly: false
       ownerOnly: true
     - path: /etc/passwd
+      readOnly: false
       ownerOnly: true
     - path: /etc/profile
+      readOnly: false
       ownerOnly: true
     - path: /etc/resolv.conf
+      readOnly: false
       ownerOnly: true
     - path: /proc/cpuinfo
+      readOnly: false
       ownerOnly: true
     - path: /proc/filesystems
+      readOnly: false
       ownerOnly: true
     - path: /proc/interrupts
+      readOnly: false
       ownerOnly: true
     - path: /proc/ioports
+      readOnly: false
       ownerOnly: true
     - path: /proc/meminfo
+      readOnly: false
       ownerOnly: true
     - path: /proc/modules
+      readOnly: false
       ownerOnly: true
     - path: /proc/mounts
+      readOnly: false
       ownerOnly: true
     - path: /proc/stat
+      readOnly: false
       ownerOnly: true
     - path: /proc/swaps
+      readOnly: false
       ownerOnly: true
     - path: /var/log/lastlog
+      readOnly: false
       ownerOnly: true
     - path: /var/log/messages
+      readOnly: false
       ownerOnly: true
     - path: /var/log/wtmp
+      readOnly: false
       ownerOnly: true
     - path: /etc/services
+      readOnly: false
       ownerOnly: true
     - path: /etc/shadow
+      readOnly: false
       ownerOnly: true
     action: Block

--- a/nist/system/ksp-nist-cp-2-8-critical-system-files.yaml
+++ b/nist/system/ksp-nist-cp-2-8-critical-system-files.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ksp-nist-cp-2-8-critical-system-files
 spec:
   tags: ["NIST", "CP-2-8"]
-  message: "Someone Tried Open Critical System Files"
+  message: "Someone Tried to Open Critical System Files"
   selector:
     matchLabels:
       pod: testpod   #change this label with your label

--- a/nist/system/ksp-nist-cp-2-8-critical-system-files.yaml
+++ b/nist/system/ksp-nist-cp-2-8-critical-system-files.yaml
@@ -1,0 +1,66 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-nist-cp-2-8-critical-system-files
+spec:
+  tags: ["STIGS", "MYSQL"]
+  message: "Someone Tried to Access MySQL Files"
+  selector:
+    matchLabels:
+      pod: testpod
+  file:
+    severity: 5
+    matchPaths:
+    - path: /etc/fstab
+      ownerOnly: true
+    - path: /etc/crontab
+      ownerOnly: true
+    - path: /etc/group
+      ownerOnly: true
+    - path: /etc/hosts
+      ownerOnly: true
+    - path: /etc/hosts.allow
+      ownerOnly: true
+    - path: /etc/hosts.deny
+      ownerOnly: true
+    - path: /etc/issue
+      ownerOnly: true
+    - path: /etc/motd
+      ownerOnly: true
+    - path: /etc/mtab
+      ownerOnly: true
+    - path: /etc/passwd
+      ownerOnly: true
+    - path: /etc/profile
+      ownerOnly: true
+    - path: /etc/resolv.conf
+      ownerOnly: true
+    - path: /proc/cpuinfo
+      ownerOnly: true
+    - path: /proc/filesystems
+      ownerOnly: true
+    - path: /proc/interrupts
+      ownerOnly: true
+    - path: /proc/ioports
+      ownerOnly: true
+    - path: /proc/meminfo
+      ownerOnly: true
+    - path: /proc/modules
+      ownerOnly: true
+    - path: /proc/mounts
+      ownerOnly: true
+    - path: /proc/stat
+      ownerOnly: true
+    - path: /proc/swaps
+      ownerOnly: true
+    - path: /var/log/lastlog
+      ownerOnly: true
+    - path: /var/log/messages
+      ownerOnly: true
+    - path: /var/log/wtmp
+      ownerOnly: true
+    - path: /etc/services
+      ownerOnly: true
+    - path: /etc/shadow
+      ownerOnly: true
+    action: Block


### PR DESCRIPTION
Organizations may choose to identify critical assets as part of criticality analysis,
business continuity planning, or business impact analyses. Organizations identify critical
system assets so that additional controls can be employed (beyond the controls routinely
implemented) to help ensure that organizational mission and business functions can
continue to be conducted during contingency operations.

Block all the paths related to critical system files as well as confidential files.