### PR TITLE
Cassandra server best practices policy

### DIFF
--- a/cassandra/network/cnp-ingress-cassandra-server-access-least-privilege.yaml
+++ b/cassandra/network/cnp-ingress-cassandra-server-access-least-privilege.yaml
@@ -1,0 +1,37 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cnp-ingress-cassandra-server-access-least-privilege"
+specs:
+  - description: Allow only permitted requests to Cassandra server.  Enforce Least Privilege
+    endpointSelector:
+      matchLabels:
+        app: cass-server    #change app: cass-server to your labels
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: testpod-limited   #change  app: testpodp-limited to your labels
+      toPorts:
+      - ports:
+        - port: "9042"
+          protocol: TCP
+        rules:
+          l7proto: cassandra
+          l7:
+          - query_action: "select"
+            query_table: "system*"
+          - query_action: "select"
+            query_table: "system_schema*"
+          - query_action: "insert"
+            query_table: "attendance.daily_records"
+    - fromEndpoints:
+      - matchLabels:
+          app: testpod-full      #change testpod-full to your labels
+      toPorts:
+      - ports:
+        - port: "9042"
+          protocol: TCP
+        rules:
+          l7proto: cassandra
+          l7:
+          - {}


### PR DESCRIPTION
To enforce least-privileged access

- [ ] Policy Enforcable
- [ ] Policy Tested and Working
- [ ] Reference: [https://docs.cilium.io/en/stable/gettingstarted/cassandra/#gs-cassandra](https://docs.cilium.io/en/stable/gettingstarted/cassandra/#gs-cassandra)

**Note**
- When using Cassandra docker version greater than 3.11.11 we need to explicitly change the protocol_version to 4 
- modified command → `kubectl  exec -it $(kubectl get po -lapp=empire-outpost -o name | cut -c5-) -- cqlsh cassandra-svc --protocol-version=4`