### PR TITLE
ksp-python-cve-2021-39182

### DIFF
--- a/python/system/ksp-python-cve-2021-39182.yaml
+++ b/python/system/ksp-python-cve-2021-39182.yaml
@@ -1,0 +1,31 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-python-cve-2021-39182
+  namespace: multiubuntu # Change your namespace
+spec:
+  tags: ["PYTHON","CVE","CVE-2021-39182","ENROCRYPT","HASHING"]
+  message: "This policy will block access from using for hashing.py from enrocrypt"
+  selector:
+    matchLabels:
+      container: ubuntu-1 # Change your match labels
+  file:
+    severity: 5
+    matchPaths:
+    # Note: Folder structure may vary
+    - path: /usr/local/lib/python3.6/dist-packages/enrocrypt/hashing.py
+    - path: /usr/local/lib/python3.6/dist-packages/enrocrypt/__init__.py
+    matchPatterns:
+    - pattern: /usr/local/lib/python?/dist-packages/enrocrypt/hashing.py
+    - pattern: /usr/local/lib/python?/dist-packages/enrocrypt/__init__.py
+    action: Block
+  process:
+    severity: 5
+    matchPaths:
+    # Note: Folder structure may vary
+    - path: /usr/local/lib/python3.6/dist-packages/enrocrypt/hashing.py
+    - path: /usr/local/lib/python3.6/dist-packages/enrocrypt/__init__.py
+    matchPatterns:
+    - pattern: /usr/local/lib/python?/dist-packages/enrocrypt/hashing.py
+    - pattern: /usr/local/lib/python?/dist-packages/enrocrypt/__init__.py
+    action: Block

--- a/python/system/ksp-python-cve-2021-39182.yaml
+++ b/python/system/ksp-python-cve-2021-39182.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: multiubuntu # Change your namespace
 spec:
   tags: ["PYTHON","CVE","CVE-2021-39182","ENROCRYPT","HASHING"]
-  message: "This policy will block access from using for hashing.py from enrocrypt"
+  message: "Hashing module from Enrocrypt is deprecated you cannot import!"
   selector:
     matchLabels:
       container: ubuntu-1 # Change your match labels


### PR DESCRIPTION
EnroCrypt is a Python module for encryption and hashing. Prior to version 1.1.4, EnroCrypt used the MD5 hashing algorithm in the hashing file. Beginners who are unfamiliar with hashes can face problems as MD5 is considered an insecure hashing algorithm. The vulnerability is patched in v1.1.4 of the product. As a workaround, users can remove the `MD5` hashing function from the file `hashing.py`.
Ref: https://nvd.nist.gov/vuln/detail/CVE-2021-39182