### PR TITLE
ksp-python-pip-cve-2019-20916

### DIFF
--- a/python/system/ksp-python-pip-cve-2019-20916.yaml
+++ b/python/system/ksp-python-pip-cve-2019-20916.yaml
@@ -1,0 +1,42 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-python-pip-cve-2019-20916
+  namespace: multiubuntu # change your match labels
+spec:
+  tags: ["Python", "CVE","PIP","CVE-2019-20196","Directory Traversal","Zip-Slip","dot-dot-slash"]
+  message: "Python module contains dot-dot-slash directories cannot be downloaded"
+  selector:
+    matchLabels:
+      container: ubuntu-1 # Change your match labels
+  file:
+    severity: 2
+    matchPaths:
+    # st is  one of the affected library for traversal attacks
+    # st is a module for serving static files on web pages
+    - path: /usr/lib/python3.6/site-packages/st/__init__.py
+    matchPatterns:
+    # Note: %2e is the URL encoded version of . (dot)
+    - pattern: /**/**/**/**/root/.ssh/id_rsa
+    - pattern: /%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa
+    - pattern: /usr/lib/**/site-packages/pip/_internal/network/download.py
+    - pattern: /usr/lib/**/**/pip/download.py
+    - pattern: /usr/lib/**/**/**/pip/**/**/download.py
+    - pattern: /usr/local/lib/python?/dist-packages/pip/_internal/network/download.py
+    action: Audit
+  process:
+    severity: 2
+    matchPaths:
+    # gh issue link: https://github.com/pypa/pip/issues/6413
+    # issue occurs in _download_http_url in src/pip/_internal/download.py
+    - path: /usr/lib/python3/site-packages/pip/_internal/network/download.py
+    - path: /usr/lib/python2/site-packages/pip/_internal/network/download.py
+    - path: /usr/local/lib/python3.5/dist-packages/pip/_internal/network/download.py
+    - path: /usr/lib/python3/dist-packages/pip/download.py
+    - path: /usr/lib/python2/dist-packages/pip/download.py
+    - path: /usr/lib/python3.6/site-packages/st/__init__.py
+    matchPatterns:
+    - pattern: /usr/lib/**/**/pip/download.py
+    - pattern: /usr/lib/**/**/**/pip/**/**/download.py
+    - pattern: /usr/local/lib/python?/dist-packages/pip/_internal/network/download.py
+    action: Audit


### PR DESCRIPTION
Affected versions of this package are vulnerable to Directory Traversal via _download_http_url in _internal/download.py. When a URL is given in an install command the Content-Disposition header can have ../ in a filename.
Ref: https://security.snyk.io/vuln/SNYK-PYTHON-PIP-609855