### PR TITLE
cnp-nist-pl-4-1-social-media-egress-block

### DIFF
--- a/nist/network/cnp-nist-pl-4-1-social-media-egress-block.yaml
+++ b/nist/network/cnp-nist-pl-4-1-social-media-egress-block.yaml
@@ -1,0 +1,56 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-nist-pl-4-1-social-media-egress-block
+spec:
+  description: "This policy will block the access to the major social media websites."
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: "UDP"
+            - port: "443"
+              protocol: "TCP"
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        - matchPattern: "*.facebook.com"
+      toPorts:
+        - ports:
+            - port: "443"
+    - toFQDNs:
+        - matchPattern: "*.instagram.com"
+      toPorts:
+        - ports:
+            - port: "443"
+    - toFQDNs:
+        - matchPattern: "*.pinterest.com"
+      toPorts:
+        - ports:
+            - port: "443"
+    - toFQDNs:
+        - matchPattern: "*.reddit.com"
+      toPorts:
+        - ports:
+            - port: "443"
+    - toFQDNs:
+        - matchPattern: "*.tiktok.com"
+      toPorts:
+        - ports:
+            - port: "443"
+    - toFQDNs:
+        - matchPattern: "*.twitter.com"
+      toPorts:
+        - ports:
+            - port: "443"
+    - toFQDNs:
+        - matchPattern: "*.youtube.com"
+      toPorts:
+        - ports:
+            - port: "443"


### PR DESCRIPTION
**Description:-**
Social media, social networking, and external site/application usage restrictions
address rules of behavior related to the use of social media, social networking, and external
sites when organizational personnel are using such sites for official duties or in the conduct
of official business, when organizational information is involved in social media and social
networking transactions, and when personnel access social media and networking sites from
organizational systems.

**Deliverable:-**
Block the all the social media network activities in pods.
(ex: facebook, twitter) and their IP addresses.
Use DNS based method to block activities.