### PR TITLE
To protect from CVE-2020-13946

### DIFF
--- a/cve/network/cnp-cve-2020-13946-ingress-deny-jmx-port-exposure-externally.yaml
+++ b/cve/network/cnp-cve-2020-13946-ingress-deny-jmx-port-exposure-externally.yaml
@@ -1,0 +1,19 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnp-cve-2020-13946-ingress-deny-jmx-port-exposure-externally
+spec:
+  description: "To block JMX port exposure over the internet"
+  endpointSelector:
+    matchLabels:
+      app: cass-server      #change app: cassandra to match your label
+  ingressDeny:
+  - fromEntities:
+    - "world"
+    toPorts:
+    - ports:
+      - port: "7199"
+        protocol: "TCP"
+  ingress:
+  - fromEntities:
+    - "all"


### PR DESCRIPTION
Blocking JMX port exposure over the internet