### PR TITLE
ksp-cve-2019-20907-python-tarfile

### DIFF
--- a/python/system/hsp-cve-2019-20907-python-tarfile.yaml
+++ b/python/system/hsp-cve-2019-20907-python-tarfile.yaml
@@ -1,0 +1,39 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: hsp-cve-2019-20907-python-tarfile
+  namespace: default    #Change with your namespace
+spec:
+  tags: ["CVE","CVE-2019-20907","Python"]
+  message: "tarfile.py accessed by unknown process"
+  nodeSelector:
+    matchLabels:
+      pod: testpod      # Change with your node label
+  file:
+    severity: 4
+    matchPaths:
+    - path: /usr/lib/python2.7/tarfile.py
+      readOnly: false
+      ownerOnly: true
+    - path: /usr/lib/python2.7/tarfile.pyc
+      readOnly: false
+      ownerOnly: true
+    - path: /usr/lib/python3/dist-packages/jedi/third_party/typeshed/stdlib/2and3/tarfile.pyi
+      readOnly: false
+      ownerOnly: true
+    - path: /usr/lib/python3.9/tarfile.py
+      readOnly: false
+      ownerOnly: true
+    action: Audit
+  process:
+    severity: 4
+    matchPaths:
+    - path: /usr/lib/python2.7/tarfile.py
+      ownerOnly: true
+    - path: /usr/lib/python2.7/tarfile.pyc
+      ownerOnly: true
+    - path: /usr/lib/python3/dist-packages/jedi/third_party/typeshed/stdlib/2and3/tarfile.pyi
+      ownerOnly: true
+    - path: /usr/lib/python3.9/tarfile.py
+      ownerOnly: true
+    action: Audit

--- a/python/system/hsp-cve-2019-20907-python-tarfile.yaml
+++ b/python/system/hsp-cve-2019-20907-python-tarfile.yaml
@@ -1,3 +1,7 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
@@ -5,7 +9,7 @@ metadata:
   namespace: default    #Change with your namespace
 spec:
   tags: ["CVE","CVE-2019-20907","Python"]
-  message: "tarfile.py accessed by unknown process"
+  message: "Python tarfile accessed by unauthorized user"
   nodeSelector:
     matchLabels:
       pod: testpod      # Change with your node label

--- a/python/system/hsp-cve-2019-20907-python-tarfile.yaml
+++ b/python/system/hsp-cve-2019-20907-python-tarfile.yaml
@@ -13,31 +13,21 @@ spec:
   nodeSelector:
     matchLabels:
       pod: testpod      # Change with your node label
-  file:
-    severity: 4
-    matchPaths:
-    - path: /usr/lib/python2.7/tarfile.py
-      readOnly: false
-      ownerOnly: true
-    - path: /usr/lib/python2.7/tarfile.pyc
-      readOnly: false
-      ownerOnly: true
-    - path: /usr/lib/python3/dist-packages/jedi/third_party/typeshed/stdlib/2and3/tarfile.pyi
-      readOnly: false
-      ownerOnly: true
-    - path: /usr/lib/python3.9/tarfile.py
-      readOnly: false
-      ownerOnly: true
-    action: Audit
   process:
     severity: 4
-    matchPaths:
-    - path: /usr/lib/python2.7/tarfile.py
+    matchPatterns:
+    - pattern: /usr/lib/python*/tarfile.py
       ownerOnly: true
-    - path: /usr/lib/python2.7/tarfile.pyc
+    - pattern: /usr/lib/python*/tarfile.pyc
       ownerOnly: true
-    - path: /usr/lib/python3/dist-packages/jedi/third_party/typeshed/stdlib/2and3/tarfile.pyi
+    action: Block
+  file:
+    severity: 4
+    matchPatterns:
+    - pattern: /usr/lib/python*/tarfile.py
+      readOnly: false
       ownerOnly: true
-    - path: /usr/lib/python3.9/tarfile.py
+    - pattern: /usr/lib/python*/tarfile.pyc
+      readOnly: false
       ownerOnly: true
-    action: Audit
+    action: Block

--- a/python/system/ksp-cve-2019-20907-python-tarfile.yaml
+++ b/python/system/ksp-cve-2019-20907-python-tarfile.yaml
@@ -5,7 +5,7 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
-  name: hsp-cve-2019-20907-python-tarfile
+  name: ksp-cve-2019-20907-python-tarfile
   namespace: default    #Change with your namespace
 spec:
   tags: ["CVE","CVE-2019-20907","Python"]

--- a/python/system/ksp-cve-2019-20907-python-tarfile.yaml
+++ b/python/system/ksp-cve-2019-20907-python-tarfile.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   tags: ["CVE","CVE-2019-20907","Python"]
   message: "Python tarfile accessed by unauthorized user"
-  nodeSelector:
+  selector:
     matchLabels:
       pod: testpod      # Change with your node label
   process:


### PR DESCRIPTION
It was discovered that Python incorrectly handled certain TAR archives.
An attacker could possibly use this issue to cause a denial of service.

In Lib/tarfile.py in Python through 3.8.3, an attacker is able to craft a TAR archive leading to an infinite loop when opened by tarfile.open, because _proc_pax lacks header validation.

https://www.cvedetails.com/cve/CVE-2019-20907/
https://ubuntu.com/security/CVE-2019-20907