### PR TITLE
ksp-python-dask-distributed-cve-2021-4234

### DIFF
--- a/python/system/ksp-python-dask-distributed-cve-2021-42343.yaml
+++ b/python/system/ksp-python-dask-distributed-cve-2021-42343.yaml
@@ -1,0 +1,53 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-python-dask-distributed-cve-2021-42343
+  namespace: default # Change your namespace
+spec:
+  tags: ["PYTHON", "CVE-2021-42343","DASK"]
+  message: "Cannot import the specified module dask"
+  selector:
+    matchLabels: 
+      container: ubuntu-1 #Change your namespace
+  file:
+    severity: 3
+    matchPaths:
+    - path: /usr/local/lib/python3.6/dist-packages/dask/distributed.py
+    - path: /usr/local/lib/python3.6/dist-packages/dask/__init__.py
+    - path: /usr/local/lib/python3.6/dist-packages/dask/config.py
+    - path: /usr/local/lib/python3.6/dist-packages/dask/dask.yaml
+      fromSource:
+      - path: /usr/bin/python3
+    matchDirectories:
+    - dir: /usr/local/lib/python3.6/dist-packages/dask/
+    matchPatterns:
+    - pattern: /usr/local/lib/python?/dist-packages/dask/distributed.py
+    - pattern: /usr/local/lib/python?/**/dask/distributed.py
+    - pattern: /usr/local/lib/python?/dist-packages/dask/__init__.py
+    - pattern: /usr/local/lib/python?/**/dask/__init__.py
+    - pattern: /usr/local/lib/python?/dist-packages/dask/config.py
+    - pattern: /usr/local/lib/python?/**/dask/config.py
+    - pattern: /usr/local/lib/python?/dist-packages/dask/dask.yaml
+    - pattern: /usr/local/lib/python?/**/dask/dask.yaml
+    action: Block
+  process:
+    severity: 3
+    matchPaths:
+    - path: /usr/local/lib/python3.6/dist-packages/dask/distributed.py
+    - path: /usr/local/lib/python3.6/dist-packages/dask/__init__.py
+    - path: /usr/local/lib/python3.6/dist-packages/dask/config.py
+    - path: /usr/local/lib/python3.6/dist-packages/dask/dask.yaml
+      fromSource:
+      - path: /usr/bin/python3
+    matchDirectories:
+    - dir: /usr/local/lib/python3.6/dist-packages/dask/
+    matchPatterns:
+    - pattern: /usr/local/lib/python?/dist-packages/dask/distributed.py
+    - pattern: /usr/local/lib/python?/**/dask/distributed.py
+    - pattern: /usr/local/lib/python?/dist-packages/dask/__init__.py
+    - pattern: /usr/local/lib/python?/**/dask/__init__.py
+    - pattern: /usr/local/lib/python?/dist-packages/dask/config.py
+    - pattern: /usr/local/lib/python?/**/dask/config.py
+    - pattern: /usr/local/lib/python?/dist-packages/dask/dask.yaml
+    - pattern: /usr/local/lib/python?/**/dask/dask.yaml
+    action: Block


### PR DESCRIPTION
An issue was discovered in the Dask distributed package before 2021.10.0 for Python. Single machine Dask clusters started with dask.distributed.LocalCluster or dask.distributed.Client (which defaults to using LocalCluster) would mistakenly configure their respective Dask workers to listen on external interfaces (typically with a randomly selected high port) rather than only on localhost. A Dask cluster created using this method (when running on a machine that has an applicable port exposed) could be used by a sophisticated attacker to achieve remote code execution.