### PR TITLE
Cassandra best practices Policy #1

### DIFF
--- a/cassandra/network/cnp-ingress-best-practice-cassandra-server-restrict-access-over-internet.yaml
+++ b/cassandra/network/cnp-ingress-best-practice-cassandra-server-restrict-access-over-internet.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cnp-ingress-best-practice-cassandra-server-restrict-access-over-internet"
+spec:
+  description: "Deny exposure of Cassandra cluster on the public internet. Enforce Least Privilege"
+  endpointSelector:
+    matchLabels:
+      app: cass-server      #change app: cassandra to match your label
+  ingressDeny:
+  - fromEntities:
+    - "world"
+    toPorts:
+    - ports:
+      - port: "7199"
+        protocol: "TCP"
+      - port: "7000"
+        protocol: "TCP"
+      - port: "7001"
+        protocol: "TCP"
+      - port: "9160"
+        protocol: "TCP"
+      - port: "9142"
+        protocol: "TCP"
+      - port: "9042"
+        protocol: "TCP"
+  ingress:
+  - fromEntities:
+    - "all"


### PR DESCRIPTION
Deny exposure of Cassandra cluster on the public internet.