### PR TITLE
cni-python-dask-distributed-cve-2021-42343

### DIFF
--- a/python/network/cni-python-dask-distributed-cve-2021-42343.yaml
+++ b/python/network/cni-python-dask-distributed-cve-2021-42343.yaml
@@ -1,0 +1,40 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cni-python-dask-distributed-cve-2021-42343
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: dask
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app: dask
+      toPorts:
+        - ports:
+            - port: "8082"
+    - toEndpoints:
+        - matchLabels:
+            app: dask
+            component: worker
+      toPorts:
+        - ports:
+            - port: "8080"
+    - toEndpoints:
+        - matchLabels:
+            app: dask
+            component: worker
+      toPorts:
+        - ports:
+            - port: "8081"
+    - toCIDRSet:
+        - cidr: 127.0.0.1/1
+      toPorts:
+        - ports:
+            - port: "8080"
+    - toCIDRSet:
+        - cidr: 127.0.0.1/1
+      toPorts:
+        - ports:
+            - port: "8082"

--- a/python/network/cni-python-dask-distributed-cve-2021-42343.yaml
+++ b/python/network/cni-python-dask-distributed-cve-2021-42343.yaml
@@ -7,13 +7,8 @@ spec:
   endpointSelector:
     matchLabels:
       app: dask
+      component: worker
   egress:
-    - toEndpoints:
-        - matchLabels:
-            app: dask
-      toPorts:
-        - ports:
-            - port: "8082"
     - toEndpoints:
         - matchLabels:
             app: dask
@@ -28,13 +23,25 @@ spec:
       toPorts:
         - ports:
             - port: "8081"
+    - toEndpoints:
+        - matchLabels:
+            app: dask
+            component: worker
+      toPorts:
+        - ports:
+            - port: "8082"
     - toCIDRSet:
-        - cidr: 127.0.0.1/1
+        - cidr: 127.0.0.1/32
       toPorts:
         - ports:
             - port: "8080"
     - toCIDRSet:
-        - cidr: 127.0.0.1/1
+        - cidr: 127.0.0.1/32
+      toPorts:
+        - ports:
+            - port: "8081"
+    - toCIDRSet:
+        - cidr: 127.0.0.1/32
       toPorts:
         - ports:
             - port: "8082"


### PR DESCRIPTION
Description link:[ NVD - CVE-2021-42343](https://nvd.nist.gov/vuln/detail/CVE-2021-42343)

An issue was discovered in the Dask distributed package before 2021.10.0 for Python. Single machine Dask clusters started with dask.distributed.LocalCluster or dask.distributed.Client (which defaults to using LocalCluster) would mistakenly configure their respective Dask workers to listen on external interfaces (typically with a randomly selected high port) rather than only on localhost. A Dask cluster created using this method (when running on a machine that has an applicable port exposed) could be used by a sophisticated attacker to achieve remote code execution.

This policy is only allowing local ports and specified ports and IPs that mentioned in Dask . It's blocking all other high ports and IPs.