### PR TITLE
ksp-cve-2019-16935-xml-rpc-server

### DIFF
--- a/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
+++ b/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
@@ -13,6 +13,72 @@ spec:
   selector:
     matchLabels:
       pod: testpod      # Change with your node label
+  process:
+    severity: 4
+    matchPatterns:
+    - pattern: /usr/lib/python*/DocXMLRPCServer.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/DocXMLRPCServer.pyc
+      ownerOnly: true
+    - pattern: /usr/lib/python*/xmlrpc/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/backports/xmlrpc/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/moves/xmlrpc/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/advancedhttpserver.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/aioconsole/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/aiohttp/web_server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/aioredis/commands/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/asgiref/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/cheroot/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/dbus/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/dnslib/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/engineio/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/faraday/start_server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/faraday_client/gui/gtk/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/faraday_client/persistence/server/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/backports/http/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/moves/http/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/ldap3/core/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/mitmproxy/proxy/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/msldap/authentication/ntlm/templates/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/paramiko/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/paste/httpserver.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/samba/tests/dns_forwarder_helpers/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/socketio/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/twisted/names/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/twisted/web/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/uvicorn/server.py
+      ownerOnly: true
+    - pattern: /usr/lib/python*/http/server.py
+      ownerOnly: true
+    - pattern: /usr/share/doc/python*/examples/http_server.py
+      ownerOnly: true
+    action: Audit
   file:
     severity: 4
     matchPatterns:

--- a/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
+++ b/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: default    #Change with your namespace
 spec:
   tags: ["CVE","CVE-2019-16935","Python","XML-RPC"]
-  message: "XML-RPC server file accessed by unknown process"
+  message: "Python XML-RPC server file accessed by unauthorized user"
   selector:
     matchLabels:
       pod: testpod      # Change with your node label

--- a/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
+++ b/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
@@ -1,0 +1,108 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: hsp-cve-2019-16935-xml-rpc-server
+  namespace: default    #Change with your namespace
+spec:
+  tags: ["CVE","CVE-2019-16935","Python","XML-RPC"]
+  message: "XML-RPC server file accessed by unknown process"
+  selector:
+    matchLabels:
+      pod: testpod      # Change with your node label
+  file:
+    severity: 4
+    matchPatterns:
+    - pattern: /usr/lib/python*/DocXMLRPCServer.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/DocXMLRPCServer.pyc
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/xmlrpc/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/backports/xmlrpc/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/moves/xmlrpc/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/advancedhttpserver.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/aioconsole/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/aiohttp/web_server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/aioredis/commands/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/asgiref/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/cheroot/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/dbus/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/dnslib/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/engineio/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/faraday/start_server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/faraday_client/gui/gtk/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/faraday_client/persistence/server/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/backports/http/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/future/moves/http/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/ldap3/core/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/mitmproxy/proxy/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/msldap/authentication/ntlm/templates/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/paramiko/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/paste/httpserver.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/samba/tests/dns_forwarder_helpers/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/socketio/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/twisted/names/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/twisted/web/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/uvicorn/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/http/server.py
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/share/doc/python*/examples/http_server.py
+      readOnly: false
+      ownerOnly: true
+    action: Audit

--- a/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
+++ b/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
@@ -78,7 +78,7 @@ spec:
       ownerOnly: true
     - pattern: /usr/share/doc/python*/examples/http_server.py
       ownerOnly: true
-    action: Audit
+    action: Block
   file:
     severity: 4
     matchPatterns:
@@ -175,4 +175,4 @@ spec:
     - pattern: /usr/share/doc/python*/examples/http_server.py
       readOnly: false
       ownerOnly: true
-    action: Audit
+    action: Block

--- a/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
+++ b/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
@@ -1,3 +1,7 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:

--- a/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
+++ b/python/system/hsp-cve-2019-16935-xml-rpc-server.yaml
@@ -5,7 +5,7 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
-  name: hsp-cve-2019-16935-xml-rpc-server
+  name: ksp-cve-2019-16935-xml-rpc-server
   namespace: default    #Change with your namespace
 spec:
   tags: ["CVE","CVE-2019-16935","Python","XML-RPC"]


### PR DESCRIPTION
The documentation XML-RPC server in Python through 2.7.16, 3.x through 3.6.9, and 3.7.x through 3.7.4 has XSS via the server_title field. This occurs in Lib/DocXMLRPCServer.py in Python 2.x, and in Lib/xmlrpc/server.py in Python 3.x. If set_server_title is called with untrusted input, arbitrary JavaScript can be delivered to clients that visit the http URL for this server.

https://www.cvedetails.com/cve/CVE-2019-16935/