### PR TITLE
ksp-cve-2019-17514-python-library-glob

### DIFF
--- a/python/system/hsp-cve-2019-17514-python-library-glob.yaml
+++ b/python/system/hsp-cve-2019-17514-python-library-glob.yaml
@@ -1,0 +1,25 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: hsp-cve-2019-17514-python-library-glob
+  namespace: default    #Change with your namespace
+spec:
+  tags: ["CVE","CVE-2019-17514","Python","glob"]
+  message: "Python glob html file accessed by unauthorized user"
+  selector:
+    matchLabels:
+      pod: testpod      # Change with your node label
+  file:
+    severity: 4
+    matchPatterns:
+    - pattern: /usr/lib/python*/dist-packages/**/library/glob.html
+      readOnly: false
+      ownerOnly: true
+    - pattern: /usr/lib/python*/dist-packages/**/**/library/glob.html
+      readOnly: false
+      ownerOnly: true
+    action: Block

--- a/python/system/ksp-cve-2019-17514-python-library-glob.yaml
+++ b/python/system/ksp-cve-2019-17514-python-library-glob.yaml
@@ -5,7 +5,7 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
-  name: hsp-cve-2019-17514-python-library-glob
+  name: ksp-cve-2019-17514-python-library-glob
   namespace: default    #Change with your namespace
 spec:
   tags: ["CVE","CVE-2019-17514","Python","glob"]


### PR DESCRIPTION
library/glob.html in the Python 2 and 3 documentation before 2016 has potentially misleading information about whether sorting occurs, as demonstrated by irreproducible cancer-research results. NOTE: the effects of this documentation cross application domains, and thus it is likely that security-relevant code elsewhere is affected. This issue is not a Python implementation bug, and there are no reports that NMR researchers were specifically relying on library/glob.html. In other words, because the older documentation stated "finds all the pathnames matching a specified pattern according to the rules used by the Unix shell," one might have incorrectly inferred that the sorting that occurs in a Unix shell also occurred for glob.glob. There is a workaround in newer versions of Willoughby nmr-data_compilation-p2.py and nmr-data_compilation-p3.py, which call sort() directly.

https://www.cvedetails.com/cve/CVE-2019-17514/