### PR TITLE
ksp-cve-2021-3426-python-pydoc

### DIFF
--- a/python/system/ksp-cve-2021-3426-python-pydoc.yaml
+++ b/python/system/ksp-cve-2021-3426-python-pydoc.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: default    #Change with your namespace
 spec:
   tags: ["CVE","CVE-2021-3426","Python","Pydoc"]
-  message: "unauthorized user tried to start Pydoc server"
+  message: "An unauthorized user attempted to launch a Pydoc server, which may use CVE-2021-3426"
   selector:
     matchLabels:
       pod: testpod      # Change with your node label

--- a/python/system/ksp-cve-2021-3426-python-pydoc.yaml
+++ b/python/system/ksp-cve-2021-3426-python-pydoc.yaml
@@ -1,0 +1,28 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-cve-2021-3426-python-pydoc
+  namespace: default    #Change with your namespace
+spec:
+  tags: ["CVE","CVE-2021-3426","Python","Pydoc"]
+  message: "unauthorized user tried to start Pydoc server"
+  selector:
+    matchLabels:
+      pod: testpod      # Change with your node label
+  process:
+    severity: 4
+    matchPaths:
+    - path: /usr/bin/pydoc
+      ownerOnly: true
+    - path: /bin/pydoc
+      ownerOnly: true
+    matchPatterns:
+    - pattern: /usr/bin/pydoc*
+      ownerOnly: true
+    - pattern: /bin/pydoc*
+      ownerOnly: true
+    action: Block


### PR DESCRIPTION
There's a flaw in Python 3's pydoc. A local or adjacent attacker who discovers or is able to convince another local or adjacent user to start a pydoc server could access the server and use it to disclose sensitive information belonging to the other user that they would not normally be able to access. The highest risk of this flaw is to data confidentiality. This flaw affects Python versions before 3.8.9, Python versions before 3.9.3, and Python versions before 3.10.0a7.

[Debian: CVE-2021-3426: python3.5, python3.7 -- security update ](https://www.rapid7.com/db/vulnerabilities/debian-cve-2021-3426/)