### PR TITLE
ksp-cve-2013-1888-python-pip-symlink

### DIFF
--- a/python/system/ksp-cve-2013-1888-python-pip-symlink.yaml
+++ b/python/system/ksp-cve-2013-1888-python-pip-symlink.yaml
@@ -1,0 +1,35 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit: 
+# https://www.accuknox.com/kubearmor/ 
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-cve-2013-1888-python-pip-symlink
+  namespace: default    #Change with your namespace
+spec:
+  tags: ["CVE","CVE-2013-1888","Python","pip","symlink"]
+  message: "unauthorized user tried to access pip build files"
+  selector:
+    matchLabels:
+      pod: testpod      #Change with your node label
+  process:
+    severity: 4
+    matchPaths:
+    - path: /usr/bin/pip
+      ownerOnly: true
+    - path: /bin/pip
+      ownerOnly: true
+    matchDirectories:
+    - dir: /tmp/pip-build/
+      ownerOnly: true
+      recursive: true
+    action: Block
+  file:
+    severity: 4
+    matchPaths:
+    matchDirectories:
+    - dir: /tmp/pip-build/
+      ownerOnly: true
+      recursive: true
+    action: Block


### PR DESCRIPTION
pip before 1.3 allows local users to overwrite arbitrary files via a symlink attack on a file in the /tmp/pip-build temporary directory.
[Gentoo Linux: CVE-2013-1888: pip: Multiple vulnerabilities ](url)