### PR TITLE
cnp-cve-2021-40978-directory-traversal

### DIFF
--- a/cve/network/cnp-cve-2021-40978-directory-traversal.yaml
+++ b/cve/network/cnp-cve-2021-40978-directory-traversal.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: cve-2021-40978-directory-traversal
+  name: cnp-cve-2021-40978-directory-traversal
 spec:
   description: "To block built-in dev-server port 8000 for directory traversal"
   endpointSelector:

--- a/cve/network/cve-2021-40978-directory-traversal.yaml
+++ b/cve/network/cve-2021-40978-directory-traversal.yaml
@@ -1,0 +1,23 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cve-2021-40978-directory-traversal
+spec:
+  description: "To block built-in dev-server port 8000 for directory traversal"
+  endpointSelector:
+    pod: testpod   #change with your match label
+  ingress:
+    - fromCIDRSet:
+        - cidr: 10.0.0.1/16
+      toPorts:
+        - ports:
+            - port: "8000"
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+    - fromEndpoints:
+        - {}
+    - fromEntities:
+        - cluster


### PR DESCRIPTION
** DISPUTED ** The mkdocs 1.2.2 built-in dev-server allows directory traversal using the port 8000, enabling remote exploitation to obtain :sensitive information. NOTE: the vendor has disputed this as described in CVE-2021-40978 - Path Traversal. · Issue #2601 · mkdocs/mkdocs  and Did you report this upstream? · Issue #1 · nisdn/CVE-2021-40978 .

nuclei-templates/CVE-2021-40978.yaml at dc22f77a5027f44a4cbc0a83e650b5297cf63ebb · projectdiscovery/nuclei-templates 