### PR TITLE
ksp-cve-2021-39327-wordpress-plugin-bulletproof-security

### DIFF
--- a/cve/system/ksp-cve-2021-39327-wordpress-plugin-bulletproof-security.yaml
+++ b/cve/system/ksp-cve-2021-39327-wordpress-plugin-bulletproof-security.yaml
@@ -1,0 +1,27 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-nucleci-cve-2021-39327
+  namespace: testns # Change your namespace
+spec:
+  tags: ["WORDPRESS", "NUCLEI", "CVE-2021-39327"]
+  message: Alert! Backup logs are not accessible.
+  selector:
+    matchLabels:
+      container: ubuntu-1 # Change your matchLabels
+  file: 
+    severity: 2
+    matchPaths:
+    - path: /var/www/html/wp-content/bps-backup/logs/db_backup_log.txt
+    - path: /var/www/html/wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt
+    action: Block
+  process: 
+    severity: 2
+    matchPaths:
+    - path: /var/www/html/wp-content/bps-backup/logs/db_backup_log.txt
+    - path: /var/www/html/wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt
+    action: Block

--- a/cve/system/ksp-cve-2021-39327-wordpress-plugin-bulletproof-security.yaml
+++ b/cve/system/ksp-cve-2021-39327-wordpress-plugin-bulletproof-security.yaml
@@ -6,22 +6,20 @@ apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
   name: ksp-nucleci-cve-2021-39327
-  namespace: testns # Change your namespace
+  namespace: default # Change your namespace
 spec:
-  tags: ["WORDPRESS", "NUCLEI", "CVE-2021-39327"]
+  tags: ["WORDPRESS", "NUCLECI", "CVE-2021-39327"]
   message: Alert! Backup logs are not accessible.
   selector:
     matchLabels:
-      container: ubuntu-1 # Change your matchLabels
+      app.kubernetes.io/name: wordpress # Change your matchLabels
+      app.kubernetes.io/instance: my-release # Change your matchLabels
   file: 
     severity: 2
     matchPaths:
-    - path: /var/www/html/wp-content/bps-backup/logs/db_backup_log.txt
-    - path: /var/www/html/wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt
-    action: Block
-  process: 
-    severity: 2
-    matchPaths:
-    - path: /var/www/html/wp-content/bps-backup/logs/db_backup_log.txt
-    - path: /var/www/html/wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt
+    - path: /bitnami/wordpress/wp-content/bps-backup/logs/db_backup_log.txt
+    - path: /bitnami/wordpress/wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt
+    matchPatterns:
+    - pattern: /**/**/wp-content/bps-backup/logs/db_backup_log.txt
+    - pattern: /**/**/wp-content/plugins/bulletproof-security/admin/htaccess/db_backup_log.txt
     action: Block


### PR DESCRIPTION
The BulletProof Security WordPress plugin is vulnerable to sensitive information disclosure due to a file path disclosure in the publicly accessible ~/db_backup_log.txt file which grants attackers the full path of the site, in addition to the path of database backup files. This affects versions up to, and including, 5.1.