### PR TITLE
ksp-cve-2021-24499-unauthenticated-rce

### DIFF
--- a/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
+++ b/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
@@ -12,7 +12,7 @@ spec:
   message: "Alert! Unknown user tried to access workreap temp files"
   selector:
     matchLabels:
-      app: wordpress
+      app: wordpress   #Change with your pod labels
   process:
     severity: 5
     matchDirectories:

--- a/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
+++ b/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
@@ -1,0 +1,24 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-cve-2021-24499-unauthenticated-rce
+  namespace: default    #Change with your namespace
+spec:
+  tags: ["CVE","CVE-2021-24499","unauthenticated-RCE"]
+  selector:
+    matchLabels:
+      app: wordpress
+  process:
+    severity: 5
+    matchDirectories:
+    - dir: /var/www/html/wp-content/uploads/workreap-temp/
+      recursive: true
+    action: Block
+  file:
+    severity: 5
+    matchDirectories:
+    - dir: /var/www/html/wp-content/uploads/workreap-temp/
+      readOnly: false
+      recursive: true
+      ownerOnly: false
+    action: Block

--- a/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
+++ b/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
@@ -1,10 +1,15 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
   name: ksp-cve-2021-24499-unauthenticated-rce
   namespace: default    #Change with your namespace
 spec:
-  tags: ["CVE","CVE-2021-24499","unauthenticated-RCE"]
+  tags: ["Wordpress","CVE","CVE-2021-24499","unauthenticated-RCE"]
+  message: "Alert! Unknown user tried to access workreap temp files"
   selector:
     matchLabels:
       app: wordpress

--- a/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
+++ b/cve/system/ksp-cve-2021-24499-unauthenticated-rce.yaml
@@ -18,6 +18,12 @@ spec:
     matchDirectories:
     - dir: /var/www/html/wp-content/uploads/workreap-temp/
       recursive: true
+      ownerOnly: false
+    matchPatterns:
+    - pattern: /**/wp-content/uploads/workreap-temp/
+      ownerOnly: false
+    - pattern: /**/**/wp-content/uploads/workreap-temp/
+      ownerOnly: false
     action: Block
   file:
     severity: 5
@@ -25,5 +31,12 @@ spec:
     - dir: /var/www/html/wp-content/uploads/workreap-temp/
       readOnly: false
       recursive: true
+      ownerOnly: false
+    matchPatterns:
+    - pattern: /**/wp-content/uploads/workreap-temp/
+      readOnly: false
+      ownerOnly: false
+    - pattern: /**/**/wp-content/uploads/workreap-temp/
+      readOnly: false
       ownerOnly: false
     action: Block


### PR DESCRIPTION
The Workreap WordPress theme before 2.2.2 AJAX actions workreap_award_temp_file_uploader and workreap_temp_file_uploader did not perform nonce checks or validate that the request is from a valid user in any other way. The endpoints allowed for uploading arbitrary files to the uploads/workreap-temp directory. Uploaded files were neither sanitized nor validated, allowing an unauthenticated visitor to upload executable code such as PHP scripts