### PR TITLE
ksp-cve-2021-30049-deny-sysaid-xss.yaml

### DIFF
--- a/cve/system/ksp-cve-2021-30049-deny-sysaid-xss.yaml
+++ b/cve/system/ksp-cve-2021-30049-deny-sysaid-xss.yaml
@@ -1,0 +1,24 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-cve-2021-30049-xss
+  namespace: default    #Change with your namespace
+spec:
+  tags: ["SysAID","CVE","CVE-2021-30049","XSS"]
+  message: "Alert! Unknown user tried to access KeepAlive.jsp script"
+  selector:
+    matchLabels:
+      app: SysAID    #Change with your pod labels
+  process:
+    severity: 6
+    matchDirectories:
+    - dir: /var/www/html/KeepAlive.jsp
+      recursive: true
+    action: Block
+  file:
+    severity: 6
+    matchDirectories:
+    - dir: /var/www/html/KeepAlive.jsp
+      readOnly: false
+      recursive: true
+    action: Block

--- a/cve/system/ksp-cve-2021-30049-deny-sysaid-xss.yaml
+++ b/cve/system/ksp-cve-2021-30049-deny-sysaid-xss.yaml
@@ -10,15 +10,15 @@ spec:
     matchLabels:
       app: SysAID    #Change with your pod labels
   process:
-    severity: 6
+    severity: 4
     matchDirectories:
     - dir: /var/www/html/KeepAlive.jsp
       recursive: true
-    action: Block
+    action: Audit
   file:
-    severity: 6
+    severity: 4
     matchDirectories:
     - dir: /var/www/html/KeepAlive.jsp
       readOnly: false
       recursive: true
-    action: Block
+    action: Audit


### PR DESCRIPTION
This vulnerability occurs due to malicious access to the KeepAlive.jsp script.

https://github.com/projectdiscovery/nuclei-templates/blob/8369de26de5f8448f7b66bf0dafb8b2346e87837/cves/2021/CVE-2021-24499.yaml