### PR TITLE
KubeArmor policy to deny path traversal and rce on apache 2.4.49

### DIFF
--- a/cve/system/ksp-cve-2021-41773-apache2.4.49-path-traversal-and-rce.yaml
+++ b/cve/system/ksp-cve-2021-41773-apache2.4.49-path-traversal-and-rce.yaml
@@ -1,0 +1,33 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit: 
+# https://www.accuknox.com/kubearmor/ 
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-cve-2021-41773-apache2.4.49-path-traversal-and-rce
+  #namespace: default # Change your namespace
+spec:
+  tags: ["CVE-2021-41773", "Apache2.4.49", "Path Traversal", "RCE"]
+  message: "Apache2 tried to access system binaries or files! Possible CVE-2021-41773 detected and denied"
+  selector:
+    matchLabels:
+      app: apache  #change this with your label
+  process:
+    severity: 5
+    matchDirectories:
+    - dir: /usr/bin/
+      recursive: true
+    - dir: /usr/local/bin/
+      recursive: true
+    - dir: /bin/
+      recursive: true
+      fromSource:
+      - path: /usr/sbin/apache2
+    action: Block
+  file:
+    severity: 5
+    matchDirectories:
+    - dir: /etc/
+      recursive: true
+    action: Block


### PR DESCRIPTION
On Apache HTTP Server 2.4.49 an attacker could use a path traversal attack to map URLs to files outside the directories configured by Alias-like directives. If CGI scripts are also enabled for these aliased paths, this could allow for remote code execution. 

Affected version: `Apache 2.4.49`

Tested and verified 

- [x] Enforceable
- [x] Solves Problem

Reference:

- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2021-41773)
- [Project Discovery ](https://github.com/projectdiscovery/nuclei-templates/blob/2c9bbf16d28e1d23b2800899cb91f289eaadf69b/cves/2021/CVE-2021-41773.yaml)