### PR TITLE
KubeArmor Policy

### DIFF
--- a/exposures/configs/ksp-yii-debugger-info.yaml
+++ b/exposures/configs/ksp-yii-debugger-info.yaml
@@ -1,0 +1,20 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-yii-debugger-info
+  namespace: default # Change to your namespace
+spec:
+  tags: ["yii", "debug", "exposure", "configs"]
+  message: "Alert! yii debugger files accessed"
+  selector:
+    matchLabels:
+      app: yii2  #Change app: yii2 to your labels 
+  file:
+    severity: 
+    matchPatterns:
+    - pattern: /**/debug/default/*
+    action: Block


### PR DESCRIPTION
-  to deny debugger information disclosure on public web