### PR TITLE
CVE-2022-0543

### DIFF
--- a/cve/system/ksp-block-cve-2022-0543-redis-rce.yaml
+++ b/cve/system/ksp-block-cve-2022-0543-redis-rce.yaml
@@ -1,0 +1,27 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-block-cve-2022-0543-redis-rce
+  namespace: redis # Change your namespace
+spec:
+  tags: ["Redis-Server","Debian", "CVE", "CVE-2022-0543","RCE","Lua Sandbox Escape"]
+  message: Alert! Possible CVE-2022-0543 (Redis Lua Sandbox Escape) denied.  
+  selector:
+    matchLabels:
+      app: redis-cart
+  file: 
+    severity: 2
+    matchPaths:
+    - path: /usr/lib/x86_64-linux-gnu/liblua5.1.so.0
+    matchPatterns:
+    - pattern: /**/liblua*
+    action: Block
+  process: 
+    severity: 2
+    matchPatterns:
+    - pattern: /**/bin/**
+    action: Block


### PR DESCRIPTION
 Lua Sandbox Escape vulnerability that allows remote attackers with the ability to execute Lua scripts to escape the Lua sandbox and execute arbitrary code on the host.

**`ID --> CVE-2022-0543`**

 **`CVSS Score --> 10 CRITICAL`**

**Checks**

- [x]  Enforceable
- [x]  Proper naming
- [x]  Proper error message
- [x]  Does not break application flow

