### PR TITLE
ksp-block-cve-2021-42342-go-ahead

### DIFF
--- a/cve/system/ksp-block-cve-2021-42342-go-ahead.yaml
+++ b/cve/system/ksp-block-cve-2021-42342-go-ahead.yaml
@@ -1,0 +1,21 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-block-cve-2021-42342-go-ahead
+  namespace: default # Change your namespace
+spec:
+  tags: ["GoAhead", "CVE", "CVE-2021-42342","RCE","file upload filter"]
+  message: Alert! Got CGI scripts without prefix, Possible CVE-2021-42342.  
+  selector:
+    matchLabels:
+      app: go-ahead
+  file: 
+    severity: 2
+    matchPatterns:
+    - pattern: /**/*.so
+    action: Block
+  process: 
+    severity: 2
+    matchPatterns:
+    - pattern: /**/bin/**
+    action: Block

--- a/cve/system/ksp-block-cve-2021-42342-go-ahead.yaml
+++ b/cve/system/ksp-block-cve-2021-42342-go-ahead.yaml
@@ -1,3 +1,7 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:


### PR DESCRIPTION
An issue was discovered in GoAhead 4.x and 5.x before 5.1.5. In the file upload filter, user form variables can be passed to CGI scripts without being prefixed with the CGI prefix. This permits tunneling untrusted environment variables into vulnerable CGI scripts.

**`ID --> CVE-2021-42342`**

 **`CVSS Score --> 9.8 CRITICAL`**

**Checks**

- [x]  Enforceable
- [x]  Proper naming
- [x]  Proper error message
- [x]  Does not break application flow

