### PR TITLE
ksp-audit-stig-v-230525-firewall-implement-rate-limiting.yaml

### DIFF
--- a/stigs/system/ksp-audit-stig-v-230525-firewall-implement-rate-limiting.yaml
+++ b/stigs/system/ksp-audit-stig-v-230525-firewall-implement-rate-limiting.yaml
@@ -1,0 +1,22 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+# Suggested Fix: Add FirewallBackend=nftables to /etc/firewalld/firewalld.conf
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-audit-stig-v-230525-firewall-implement-rate-limiting
+  namespace: default # Change your name space
+spec:
+  tags: ["STIGS", "RHEL8", "STIG V-230525", "Firewall", "rate-limiting"]
+  message: "Alert! firewalld.conf has been accessed"
+  selector:
+    matchLabels:
+      app: rhel8 # Change your matchLabels
+  file:
+    severity: 5
+    matchPaths:
+    - path: /etc/firewalld/firewalld.conf   # change firewalld.conf file path 
+  action: Block

--- a/stigs/system/ksp-audit-stig-v-230525-firewall-implement-rate-limiting.yaml
+++ b/stigs/system/ksp-audit-stig-v-230525-firewall-implement-rate-limiting.yaml
@@ -2,6 +2,7 @@
 # To learn more about KubeArmor visit:
 # https://www.accuknox.com/kubearmor/
 
+# STIG reference https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2021-03-04/finding/V-230525
 # Suggested Fix: Add FirewallBackend=nftables to /etc/firewalld/firewalld.conf
 
 apiVersion: security.kubearmor.com/v1


### PR DESCRIPTION
RHEL V-230525 states that 
```
A firewall must be able to protect against or limit the effects of Denial of Service (DoS) attacks 
by ensuring RHEL 8 can implement rate-limiting measures on impacted network interfaces.
``` 
and the fix indicates that **`FirewallBackend=nftables`** should be added to **`/etc/firewalld/firewalld.conf`** file. 

With the current KubeArmor/Cilium capabilities we cannot limit the number of requests happening to a pod or node.
 
cc: @salman-accuknox @raviknox 