### PR TITLE
CASSANDRA STIG V-72663  

### DIFF
--- a/stigs/system/ksp-audit-cassandra-stig-v-72663-validated-cryptographic-modules.yaml
+++ b/stigs/system/ksp-audit-cassandra-stig-v-72663-validated-cryptographic-modules.yaml
@@ -1,0 +1,23 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+# Reference: https://www.stigviewer.com/stig/vrealize_-_cassandra/2017-06-06/finding/V-72663 
+# Suggested Fix: Configure the Cassandra Server to use NIST FIPS 140-2 validated cryptographic modules for cryptographic operations.
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-audit-cassandra-stig-v-72663-validated-cryptographic-modules
+  namespace: default # Change your name space
+spec:
+  tags: ["STIGS", "CASSANDRA", "STIG V-72663", "Cryptography", "validated cryptographic modules"]
+  message: "Alert! ssl-global.conf file has been accessed"
+  selector:
+    matchLabels:
+      app: cassandra # Change your matchLabels
+  file:
+    severity: 5
+    matchPaths:
+    - path: /usr/lib64/apache2-prefork/mod_ssl.so   # change mod_ssl.so file path 
+  action: Audit


### PR DESCRIPTION
CASSANDRA STIG V-72663 states that

`The Cassandra Server must use NIST FIPS 140-2 validated cryptographic modules for cryptographic operations.`

Fix:
```
Replace the mod_ssl.so with the following command:
cd /usr/lib64/apache2-prefork/
cp mod_ssl.so mod_ssl.so.old
cp mod_ssl.so.FIPSON.openssl1.0.2 mod_ssl.so

Modify your Apache2 configuration by editing the /etc/apache2/ssl-global.conf file.

Search for the line and add the SSLFIPS on directive below it.

Reset the Apache configuration with the service apache2 restart command.
``` 
With the current KubeArmor/Cilium capabilities we cannot limit the number of requests happening to a pod or node.