### PR TITLE
ksp-audit-stig-v-235161-monitor-my.cnf-file.yaml

### DIFF
--- a/stigs/system/ksp-audit-stig-v-235161-monitor-my.cnf-file.yaml
+++ b/stigs/system/ksp-audit-stig-v-235161-monitor-my.cnf-file.yaml
@@ -1,0 +1,21 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+# https://www.stigviewer.com/stig/oracle_mysql_8.0/2021-12-10/finding/V-235161
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-audit-stig-v-235161-monitor-my.cnf-file
+  namespace: default # Change your namespace
+spec:
+  tags: ["stig", "log", "MySQL", "v-235161"]
+  message: "Alert! my.cnf is accessed."
+  selector:
+    matchLabels:
+      app: mysql # Change your matchLabels
+  file:
+    severity: 2
+    matchPaths:
+    - path: /**/my.cnf #
+    action: Audit


### PR DESCRIPTION
The MySQL Database Server 8.0 must protect its audit configuration from unauthorized modification.

Fix   

Remove audit-related permissions from individuals and roles not authorized to have them.

REVOKE AUDIT_ADMIN on *.* FROM ;

Set audit log format to use AES encryption.
sudo vi /etc/my.cnf
[mysqld]
early-plugin-load=keyring_file.so
audit-log=FORCE_PLUS_PERMANENT
audit-log-format=JSON
audit-log-encryption=AES

Right now this solution is out of scope for kubearmor and cilium. 