### PR TITLE
There must be no shosts.equiv files on the RHEL 8 operating system.

### DIFF
--- a/stigs/system/ksp-block-stig-rhel-v-230283-no-shosts.equiv-files-on-rhel8.yaml
+++ b/stigs/system/ksp-block-stig-rhel-v-230283-no-shosts.equiv-files-on-rhel8.yaml
@@ -1,0 +1,26 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+
+# STIG Reference -- https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2021-12-03/finding/V-230283 
+# STIG Fix: Remove any found "shosts.equiv" files from the system.
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-block-stig-rhel-v-230283-no-shosts.equiv-files-on-rhel8
+  namespace: default # Change your namespace
+spec:
+  tags: ["STIG", "RHEL", "STIG V-230283", "shosts.equiv"]
+  message: "Alert! shosts.equiv file blocked"
+  selector:
+    matchLabels:
+      app: redhat # Change your matchLabels
+  file:
+    severity: 5
+    matchPatterns:
+    - pattern: /**/shosts.equiv
+    matchPaths:
+    - path: /shosts.equiv
+    action: Block


### PR DESCRIPTION
### There must be no shosts.equiv files on the RHEL 8 operating system.

**`ID` --> STIG V-230283**

 **`Reference` --> [RHEL STIG V-230283](https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2021-12-03/finding/V-230283)**

**Checks**

- [x]  Enforceable
- [x]  Proper naming
- [x]  Proper error message
- [x]  Does not break application flow
