### PR TITLE
Create cnp-block-elasticsearch-memory-leak-cve-2021-22145.yaml

### DIFF
--- a/cve/network/cnp-block-elasticsearch-memory-leak-cve-2021-22145.yaml
+++ b/cve/network/cnp-block-elasticsearch-memory-leak-cve-2021-22145.yaml
@@ -1,0 +1,22 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cnp-block-elasticsearch-memory-leak-cve-2021-22145"
+  namespace: default                #change default namespace to match your namespace
+spec:
+  description: "Policy to deny POST request to endpoint /_bulk from internet"
+  endpointSelector:
+    matchLabels:
+      service: elasticsearch        #change service: elasticsearch to match your elasticsearch pod label
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        app: kibana                 #change app: kibana to match your kibana pod label
+    toPorts:
+    - ports:
+      - port: "9200"
+        protocol: TCP
+      rules:
+        http:
+        - method: "POST"
+          path: "/_bulk"


### PR DESCRIPTION
### ElasticSearch 7.13.3 - Memory disclosure 

#### CVE : CVE-2021-22145