### PR TITLE
KubeArmor generic allow policy 

### DIFF
--- a/golang/system/ksp-allow-golang-tcp-udp-packets-from-pod.yaml
+++ b/golang/system/ksp-allow-golang-tcp-udp-packets-from-pod.yaml
@@ -1,0 +1,25 @@
+# KubeArmor is an open source software that enables you to protect your cloud workload at run-time.
+# To learn more about KubeArmor visit:
+# https://www.accuknox.com/kubearmor/
+
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: ksp-allow-golang-tcp-udp-packets-from-pod
+  namespace: default		#change namespace to match your namespace
+spec:
+  tags: ["GoLang", "Generic", "Allow policy", "Baseline policy","TCP-UDP packets"]
+  message: "TCP-UDP packets crafted by golang binary."
+  selector:
+    matchLabels:
+      app: cinema-bookings	#change label to match your label
+  network:
+    severity: 1
+    matchProtocols:
+    - protocol: tcp
+      fromSource:
+      - path: /cinema-bookins	#change binary path to match your binary path
+    - protocol: udp
+      fromSource:
+      - path: /cinema-bookins	#change binary path to match your binary path
+    action: Allow


### PR DESCRIPTION
For Golang workloads to allow TCP-UDP packets