### PR TITLE
Adding NIST SC-2 tag to existing policies

### DIFF
--- a/cve/system/ksp-cve-2019-14287-sudo-privilege-escalation.yaml
+++ b/cve/system/ksp-cve-2019-14287-sudo-privilege-escalation.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ksp-cve-2019-14287-sudo-privilege-escalation
   namespace: default # Change your namespace
 spec:
-  tags: ["CVE", "Sudo-Privilege-Escalation", "CVE-2019-14287"]
+  tags: ["CVE", "Sudo-Privilege-Escalation", "CVE-2019-14287","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   message: "Alert! Non Root User Tried to Run sudo Command"
   selector:
     matchLabels:

--- a/cve/system/ksp-cve-2021-21389-deny-buddypress-privilege-escalation-rce.yaml
+++ b/cve/system/ksp-cve-2021-21389-deny-buddypress-privilege-escalation-rce.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ksp-cve-2021-21389-deny-buddypress-privilege-escalation-rce
   namespace: default # Change your namespace
 spec:
-  tags: ["CVE", "BuddyPress-RCE", "BuddyPress-Privilege-Escalation", "CVE-2021-21389"]
+  tags: ["CVE", "BuddyPress-RCE", "BuddyPress-Privilege-Escalation", "CVE-2021-21389","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   message: "Alert! *.php file upload to wp-content subdirectory detected! Possible Privilege Escalation"
   selector:
     matchLabels:

--- a/cve/system/ksp-cve-2021-4034-polkit-vulnerability.yaml
+++ b/cve/system/ksp-cve-2021-4034-polkit-vulnerability.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ksp-cve-2021-4034-polkit-privilege-escalation
   namespace: default #change the namespace to match your requirement
 spec:
-  tags: ["CVE-2021-4034", "Shell-acess", "Polkit", "MITRE", "TA0004", "T1068", "TA0111", "Privilege Escalation"]
+  tags: ["CVE-2021-4034", "Shell-acess", "Polkit", "MITRE", "TA0004", "T1068", "TA0111", "Privilege Escalation","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   message: "Alert! pkexec binary is blocked"
   selector:
     matchLabels:

--- a/cve/system/ksp-cve-2022-0185-block-container-escape.yaml
+++ b/cve/system/ksp-cve-2022-0185-block-container-escape.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ksp-cve-2022-0185-block-container-escape
   namespace: default   #change the namespace your requirement 
 spec:
-  tags: ["CVE","K8s","CVE-2022-0185", "Privilege Escalation", "Heap Overflow"]
+  tags: ["CVE","K8s","CVE-2022-0185", "Privilege Escalation", "Heap Overflow","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   message: "Alert! Privileged functions invoked, possible exploitation of CVE-2022-0185 "
   selector:
     matchLabels:

--- a/java/system/ksp-cve-2020-9484-privilege-escalation.yaml
+++ b/java/system/ksp-cve-2020-9484-privilege-escalation.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ksp-cve-2020-9484-privilege-escalation
   namespace: default #use your namespace here
 spec:
-  tags: ["apache","CVE-2020-9484","privilege-escalation"]
+  tags: ["apache","CVE-2020-9484","privilege-escalation","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   message: "Alert! Someone tried to access the sensitive files. Possibly CVE-2020-9484-privilege-escalation detected and blocked"
   selector:
     matchLabels:

--- a/mitre/system/hsp-mitre-host-block-s-bit.yaml
+++ b/mitre/system/hsp-mitre-host-block-s-bit.yaml
@@ -8,7 +8,7 @@ metadata:
   name: hsp-mitre-t1548-setuid-setgid
 spec:
   message: Blocked the setuid or setgid flag files
-  tags : ["MITRE", "Privilege Escalation", "S-Bit"]
+  tags : ["MITRE", "Privilege Escalation", "S-Bit","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   nodeSelector:
     matchLabels:
         kubernetes.io/hostname: ubuntu  # use your own label here

--- a/mitre/system/hsp-mitre-ptrace-syscall.yaml
+++ b/mitre/system/hsp-mitre-ptrace-syscall.yaml
@@ -7,7 +7,7 @@ kind: KubeArmorHostPolicy
 metadata:
   name: hsp-mitre-ptrace-syscall
 spec:
-  tags : ["MITRE", "T1055.008", "Privilege Escalation", "P-trace"]
+  tags : ["MITRE", "T1055.008", "Privilege Escalation", "P-trace","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   message: "Alert! ptrace access denied"
   nodeSelector:
     matchLabels:

--- a/mitre/system/ksp-mitre-block-s-bit.yaml
+++ b/mitre/system/ksp-mitre-block-s-bit.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: default # Change your namespace
 spec:
   message: "Blocked the setuid or setgid flag"
-  tags : ["MITRE", "T1548.001", "Privilege Escalation", "S-Bit"]
+  tags : ["MITRE", "T1548.001", "Privilege Escalation", "S-Bit","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   selector:
     matchLabels:
         container: ubuntu  # use your own label here

--- a/mitre/system/ksp-preload_modif.yaml
+++ b/mitre/system/ksp-preload_modif.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ksp-mitre-tactic-privilege-escalation-shared-object
   namespace: default  #change with your namespace
 spec:
-  tags: ["MITRE"]
+  tags: ["MITRE","NIST","NIST-800-53-r5","SC-2","Separation of System and User Functionality"]
   message: "ld.so.preload file accessed by unknown process"
   selector:
     matchLabels:


### PR DESCRIPTION
## Changelog

Added tags `"NIST"` `"NIST-800-53-r5"` `"SC-2"` `"Separation of System and User Functionality"`  to the following policies

```
./java/system/ksp-cve-2020-9484-privilege-escalation.yaml
./mitre/system/ksp-preload_modif.yaml
./mitre/system/ksp-mitre-block-s-bit.yaml
./mitre/system/hsp-mitre-host-block-s-bit.yaml
./mitre/system/hsp-mitre-ptrace-syscall.yaml
./cve/system/ksp-cve-2019-14287-sudo-privilege-escalation.yaml
./cve/system/ksp-cve-2022-0185-block-container-escape.yaml
./cve/system/ksp-cve-2021-21389-deny-buddypress-privilege-escalation-rce.yaml
./cve/system/ksp-cve-2021-4034-polkit-vulnerability.yaml
```