### PR TITLE
generic systems policies's metadata.yaml is updated

### DIFF
--- a/MySQL/system/metadata.yaml
+++ b/MySQL/system/metadata.yaml
@@ -1,4 +1,4 @@
-version: v0.1.8
+version: v0.1.9
 policyRules:
 - name: user-grp-mod
   precondition: 

--- a/elastic/system/metadata.yaml
+++ b/elastic/system/metadata.yaml
@@ -1,4 +1,4 @@
-version: v0.1.8
+version: v0.1.9
 policyRules:
 - name: elasticsearch-indices-dir
   precondition: 

--- a/generic/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
+++ b/generic/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
@@ -19,6 +19,7 @@ spec:
     - path: /usr/bin/apt
     - path: /usr/bin/apt-get
     - path: /bin/apt-get
+    - path: /sbin/apk
     - path: /bin/apt
     - path: /usr/bin/dpkg
     - path: /bin/dpkg

--- a/generic/system/metadata.yaml
+++ b/generic/system/metadata.yaml
@@ -1,4 +1,4 @@
-version: v0.1.8
+version: v0.1.9
 policyRules:
 - name: maint-tools-access
   precondition:
@@ -118,6 +118,7 @@ policyRules:
 - name: k8s-client-tool-exec
   precondition: 
   - /usr/local/bin/kubectl
+  - OPTSCAN
   description:
     refs:
     - name: MITRE_T1609_container_administration_command
@@ -177,7 +178,6 @@ policyRules:
 - name: file-system-mounts
   precondition: 
   - /bin/mount
-  - OPTSCAN
   description:
     refs:
     - name: CIS_4.1.14_file_system_mount
@@ -199,7 +199,6 @@ policyRules:
 - name: cis-commandline-warning-banner
   precondition: 
   - /etc/motd
-  - OPTSCAN
   description:
     refs:
     - name: CIS_1.7.1_Command_Line_Warning_Banners
@@ -212,7 +211,6 @@ policyRules:
 - name: access-ctrl-permission-mod
   precondition: 
   - /bin/chmod
-  - OPTSCAN
   description:
     refs:
     - name: CIS_4.1.11_system_access_control_permission
@@ -233,7 +231,6 @@ policyRules:
 - name: sys-admin-scope-mod
   precondition: 
   - /etc/sudoers
-  - OPTSCAN
   description:
     refs:
     - name: CIS_4.1.16_system_administration_scope
@@ -250,7 +247,6 @@ policyRules:
 - name: system-files-mod
   precondition: 
   - /etc/sudoers
-  - OPTSCAN
   description:
     refs:
     - name: CIS_6.1_System_File_Permissions
@@ -265,7 +261,6 @@ policyRules:
 - name: system-mandatory-access-ctrl-mod
   precondition: 
   - /etc/selinux/
-  - OPTSCAN
   description:
     refs:
     - name: CIS_4.1.8_system_mandatory_access_controls
@@ -281,7 +276,6 @@ policyRules:
 - name: system-network-env-mod
   precondition: 
   - /etc/issue
-  - OPTSCAN
   description:
     refs:
     - name: CIS_4.1.7_system_network_environment
@@ -298,7 +292,6 @@ policyRules:
 - name: service-clients-exec
   precondition: 
   - /usr/bin/telnet
-  - OPTSCAN
   description:
     refs:
     - name: CIS_2.3_Service_Clients

--- a/kibana/system/metadata.yaml
+++ b/kibana/system/metadata.yaml
@@ -1,4 +1,4 @@
-version: v0.1.8
+version: v0.1.9
 policyRules:
 - name: kibana-panel
   precondition: 

--- a/redis/system/metadata.yaml
+++ b/redis/system/metadata.yaml
@@ -1,4 +1,4 @@
-version: v0.1.8
+version: v0.1.9
 policyRules:
 - name: redis-sys-path
   precondition: 


### PR DESCRIPTION
- Removed redundant rules (mostly `/bin/* , * , based rules are likely generate more policies) 
- Removed  `OPTSCAN` for redundant rules.