### PR TITLE
fix: Change validationFailureAction to audit for backwards compatibility

### DIFF
--- a/generic/kyverno/kyverno-automount-service-account-token.yaml
+++ b/generic/kyverno/kyverno-automount-service-account-token.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restrict-automount-sa-token
   namespace: default
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: validate-automountServiceAccountToken


### PR DESCRIPTION
Signed-off-by: Vyom-Yadav [jackhammervyom@gmail.com](mailto:jackhammervyom@gmail.com)

---

`validationFailureAction` was changed from `Audit` -> `audit` for backwards compatibility. 
Since the minimum version for this policy is `1.6.0`, this change is required to support it.

Kyverno has deprecated `audit` and `enforce`. See https://github.com/kyverno/kyverno/pull/5152

Failure actions `audit` and `enforce` are deprecated and will be removed in `v1.11.0`. After their removal, we will:
- Change `audit` -> `Audit`
- Bump min required Kyverno version


