### PR TITLE
feat: Add apk manager in package manager execution KSP

### DIFF
--- a/nist/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
+++ b/nist/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
@@ -20,6 +20,7 @@ spec:
     - path: /usr/bin/apt-get
     - path: /bin/apt-get
     - path: /bin/apt
+    - path: /sbin/apk
     - path: /usr/bin/dpkg
     - path: /bin/dpkg
     - path: /usr/bin/gdebi


### PR DESCRIPTION
This PR adds the alpine package manager `apk` to block its execution.