### PR TITLE
include missing rpm pkg managers

### DIFF
--- a/cis/system/ksp-audit-cis-mysql-1-5.yaml
+++ b/cis/system/ksp-audit-cis-mysql-1-5.yaml
@@ -18,4 +18,5 @@ spec:
     matchPaths:
     - path: /bin/false
     - path: /sbin/nologin
+    - path: /usr/sbin/nologin
     action: Audit

--- a/cis/system/ksp-block-cis-centos-8-1-1-4-1.yaml
+++ b/cis/system/ksp-block-cis-centos-8-1-1-4-1.yaml
@@ -21,4 +21,5 @@ spec:
       - path: /usr/bin/auditd
       - path: /bin/auditd
       - path: /sbin/auditd
+      - path: /usr/sbin/auditd
     action: Block

--- a/elastic/system/ksp-audit-elasticsearch-bash-spawn.yaml
+++ b/elastic/system/ksp-audit-elasticsearch-bash-spawn.yaml
@@ -19,5 +19,6 @@ spec:
     - path: /bin/bash
     - path: /bin/sh
     - path: /sbin/sh
+    - path: /usr/sbin/sh
     - path: /bin/csh
   action: Audit

--- a/golang/system/ksp-block-golang-generic-policy-1.yaml
+++ b/golang/system/ksp-block-golang-generic-policy-1.yaml
@@ -19,6 +19,9 @@ spec:
     - path: /sbin/ldconfig
       fromSource:
       - path: /usr/bin/python2.7
+    - path: /usr/sbin/ldconfig
+      fromSource:
+      - path: /usr/bin/python2.7
     - path: /usr/bin/whoami
       fromSource:
       - path: /bin/dash

--- a/malware/system/ksp-block-sysrv-hello-malware.yaml
+++ b/malware/system/ksp-block-sysrv-hello-malware.yaml
@@ -22,6 +22,7 @@ spec:
   process:
     matchPaths:
     - path: /sbin/iptables
+    - path: /usr/sbin/iptables
     - path: /etc/iptables
     - path: /usr/share/iptables
     - path: /usr/sbin/ufw

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,6 +18,8 @@ policyRules:
       matchDirectories:
       - dir: /sbin/
         recursive: true
+      - dir: /usr/sbin/
+        recursive: true
     message: restricted maintenance tool access attempted
     selector:
       matchLabels:

--- a/nist/system/ksp-nist-cm-5-3-cm-14-signed-components.yaml
+++ b/nist/system/ksp-nist-cm-5-3-cm-14-signed-components.yaml
@@ -20,6 +20,9 @@ spec:
     matchPaths:
     - path: /usr/sbin/alternatives  
     - path: /usr/bin/dnf
+    - path: /usr/bin/dnf-3
+    - path: /usr/bin/dnf5
+    - path: /usr/bin/microdnf
     - path: /usr/bin/rpm
     - path: /usr/bin/yum
     - path: /usr/bin/rpmkeys

--- a/nist/system/ksp-nist-cm-7-5-software-install.yaml
+++ b/nist/system/ksp-nist-cm-7-5-software-install.yaml
@@ -42,6 +42,12 @@ spec:
       ownerOnly: true
     - path: /usr/bin/dnf
       ownerOnly: true
+    - path: /usr/bin/dnf-3
+      ownerOnly: true
+    - path: /usr/bin/dnf5
+      ownerOnly: true
+    - path: /usr/bin/microdnf
+      ownerOnly: true
     - path: /bin/dnf
       ownerOnly: true
     - path: /usr/bin/pacman

--- a/nist/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
+++ b/nist/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
@@ -33,6 +33,9 @@ spec:
     - path: /bin/rpm
     - path: /usr/bin/dnf
     - path: /bin/dnf
+    - path: /usr/bin/dnf-3
+    - path: /usr/bin/dnf5
+    - path: /usr/bin/microdnf
     - path: /usr/bin/pacman
     - path: /usr/sbin/pacman
     - path: /bin/pacman

--- a/nist/system/ksp-system-information-blockwithaudit.yaml
+++ b/nist/system/ksp-system-information-blockwithaudit.yaml
@@ -28,4 +28,5 @@ spec:
     - path: /bin/lsblk
     - path: /usr/bin/lspci
     - path: /sbin/fdisk
+    - path: /usr/sbin/fdisk
     action: Block

--- a/stigs/system/hsp-audit-stig-ubuntu-20-010173-unix-update.yaml
+++ b/stigs/system/hsp-audit-stig-ubuntu-20-010173-unix-update.yaml
@@ -13,5 +13,6 @@ spec:
   process:
     matchPaths:
     - path: /sbin/unix_update
+    - path: /usr/sbin/unix_update
     action:
       Audit


### PR DESCRIPTION
This commit includes missing rpm pkg managers paths in the policies.

Also, in fedora, centos stream and redhat, `dnf` is actually a link to `dnf-3`, so the existing `/usr/bin/dnf` block doesn't work.

```
$ podman run -it quay.io/fedora/fedora:latest ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Nov 14  2023 /usr/bin/dnf -> dnf-3

$ podman run -it docker.io/redhat/ubi8:latest ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Oct 16  2023 /usr/bin/dnf -> dnf-3

$ podman run -it docker.io/redhat/ubi9:latest ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Jun 29  2023 /usr/bin/dnf -> dnf-3

$ podman run -it quay.io/centos/centos:stream9 ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Jun 29  2023 /usr/bin/dnf -> dnf-3

$ podman run -it docker.io/redhat/ubi9-minimal:latest ls -l /usr/bin/microdnf
-rwxr-xr-x. 1 root root 104904 Jan  6  2023 /usr/bin/microdnf

$ podman run -it docker.io/redhat/ubi8-minimal:latest ls -l /usr/bin/microdnf
-rwxr-xr-x. 1 root root 102352 May 21  2021 /usr/bin/microdnf
```

`/usr/bin/dnf5` is not part of the fedora container yet, but it is in regular fedora, so it will eventually find its way to it.



I also added a commit to include `/usr/sbin` when `/sbin` is referenced, since in redhat and fedora systems, `/sbin` is a link to `/usr/sbin`. They were merged long ago. There is also an effort going on in Fedora right now to merge `/usr/sbin` with `/usr/bin`, which will be reflected in enterprise linux OS eventually.