### PR TITLE
include missing rpm pkg managers

### DIFF
--- a/generic/system/ksp-audit-maintenance-tool-access.yaml
+++ b/generic/system/ksp-audit-maintenance-tool-access.yaml
@@ -17,4 +17,6 @@ spec:
       matchDirectories:
       - dir: /sbin/
         recursive: true
+      - dir: /usr/sbin/
+        recursive: true
   action: Audit

--- a/generic/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
+++ b/generic/system/ksp-nist-si-4-execute-package-management-process-in-container.yaml
@@ -26,6 +26,9 @@ spec:
     - execname: yum
     - execname: rpm
     - execname: dnf
+    - execname: dnf5
+    - execname: dnf-3
+    - execname: microdnf
     - execname: pacman
     - execname: makepkg
     - execname: yaourt


### PR DESCRIPTION
This commit includes missing rpm pkg managers paths in the policies.

Also, in fedora, centos stream and redhat, `dnf` is actually a link to `dnf-3`, so the existing `/usr/bin/dnf` block doesn't work.

```
$ podman run -it quay.io/fedora/fedora:latest ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Nov 14  2023 /usr/bin/dnf -> dnf-3

$ podman run -it docker.io/redhat/ubi8:latest ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Oct 16  2023 /usr/bin/dnf -> dnf-3

$ podman run -it docker.io/redhat/ubi9:latest ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Jun 29  2023 /usr/bin/dnf -> dnf-3

$ podman run -it quay.io/centos/centos:stream9 ls -l /usr/bin/dnf
lrwxrwxrwx. 1 root root 5 Jun 29  2023 /usr/bin/dnf -> dnf-3

$ podman run -it docker.io/redhat/ubi9-minimal:latest ls -l /usr/bin/microdnf
-rwxr-xr-x. 1 root root 104904 Jan  6  2023 /usr/bin/microdnf

$ podman run -it docker.io/redhat/ubi8-minimal:latest ls -l /usr/bin/microdnf
-rwxr-xr-x. 1 root root 102352 May 21  2021 /usr/bin/microdnf
```

`/usr/bin/dnf5` is not part of the fedora container yet, but it is in regular fedora, so it will eventually find its way to it.

I also added a commit to include `/usr/sbin` when `/sbin` is referenced, since in redhat and fedora systems, `/sbin` is a link to `/usr/sbin`. They were merged long ago. 