### PR TITLE
Add FIM Tag to File Integrity Policy

### DIFF
--- a/generic/system/ksp-file-integrity-monitoring.yaml
+++ b/generic/system/ksp-file-integrity-monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: file-integrity-monitoring
   namespace: default
 spec:
-  tags: ["NIST", "NIST_800-53_AU-2", "NIST_800-53_SI-4" , "MITRE", "MITRE_T1036_masquerading", "MITRE_T1565_data_manipulation"]
+  tags: ["NIST", "NIST_800-53_AU-2", "NIST_800-53_SI-4" , "MITRE", "MITRE_T1036_masquerading", "MITRE_T1565_data_manipulation", "FIM"]
   message: "Detected and prevented compromise to File integrity"
   severity: 1
   selector:


### PR DESCRIPTION
This PR adds the FIM (File Integrity Monitoring) tag to the existing file integrity policy to enable tracking of all file integrity violations across clusters. The FIM tag will allow us to categorize and filter violations more effectively, enhancing our security posture by focusing on unauthorized file changes within the environment.

**Changes:**

- Added FIM tag to file integrity policy.

**Impact:** This enhancement will streamline the process of detecting file integrity violations in clusters and improve the visibility of security incidents.

